### PR TITLE
feat(api): Plan C — Notifications email/in-app, Guests bulk, Discovery paginé

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { AiModule } from './modules/ai/ai.module';
 import { EmailsModule } from './modules/emails/emails.module';
 import { InvitationsModule } from './modules/invitations/invitations.module';
 import { NotificationsModule } from './modules/notifications/notifications.module';
+import { WaitlistModule } from './modules/waitlist/waitlist.module';
 
 @Module({
   imports: [
@@ -57,6 +58,7 @@ import { NotificationsModule } from './modules/notifications/notifications.modul
     AiModule,
     InvitationsModule,
     NotificationsModule,
+    WaitlistModule,
   ],
   providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
 })

--- a/src/modules/discovery/discovery.controller.ts
+++ b/src/modules/discovery/discovery.controller.ts
@@ -34,4 +34,52 @@ export class DiscoveryController {
   featured(@Query('limit') limit?: string) {
     return this.discoveryService.featuredEvents(limit ? parseInt(limit, 10) : 6);
   }
+
+  @Get('events')
+  @ApiOperation({ summary: 'Lister les événements publics paginés' })
+  @ApiQuery({ name: 'q', required: false, type: String })
+  @ApiQuery({ name: 'city', required: false, type: String })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 12 })
+  @ApiResponse({ status: 200, description: 'Liste paginée d\'événements' })
+  findEvents(
+    @Query('q') q?: string,
+    @Query('city') city?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.discoveryService.findEvents(q, city, page ? parseInt(page, 10) : 1, limit ? parseInt(limit, 10) : 12);
+  }
+
+  @Get('vendors')
+  @ApiOperation({ summary: 'Lister les prestataires actifs paginés' })
+  @ApiQuery({ name: 'q', required: false, type: String })
+  @ApiQuery({ name: 'category', required: false, type: String })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 12 })
+  @ApiResponse({ status: 200, description: 'Liste paginée de prestataires' })
+  findVendors(
+    @Query('q') q?: string,
+    @Query('category') category?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.discoveryService.findVendors(q, category, page ? parseInt(page, 10) : 1, limit ? parseInt(limit, 10) : 12);
+  }
+
+  @Get('venues')
+  @ApiOperation({ summary: 'Lister les salles actives paginées' })
+  @ApiQuery({ name: 'q', required: false, type: String })
+  @ApiQuery({ name: 'city', required: false, type: String })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 12 })
+  @ApiResponse({ status: 200, description: 'Liste paginée de salles' })
+  findVenues(
+    @Query('q') q?: string,
+    @Query('city') city?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.discoveryService.findVenues(q, city, page ? parseInt(page, 10) : 1, limit ? parseInt(limit, 10) : 12);
+  }
 }

--- a/src/modules/discovery/discovery.service.ts
+++ b/src/modules/discovery/discovery.service.ts
@@ -59,4 +59,40 @@ export class DiscoveryService {
       .lean()
       .select('title startDate location coverImage slug');
   }
+
+  async findEvents(q?: string, city?: string, page = 1, limit = 12): Promise<{ data: Event[]; total: number }> {
+    const filter: Record<string, unknown> = {
+      status: EventStatus.PUBLISHED,
+      visibility: EventVisibility.PUBLIC,
+    };
+    if (q) filter['$or'] = [{ title: { $regex: q, $options: 'i' } }, { description: { $regex: q, $options: 'i' } }];
+    if (city) filter['location.city'] = { $regex: city, $options: 'i' };
+    const [data, total] = await Promise.all([
+      this.eventModel.find(filter).sort({ startDate: 1 }).skip((page - 1) * limit).limit(limit).lean().select('title startDate location status slug coverImage'),
+      this.eventModel.countDocuments(filter),
+    ]);
+    return { data, total };
+  }
+
+  async findVendors(q?: string, category?: string, page = 1, limit = 12): Promise<{ data: VendorProfile[]; total: number }> {
+    const filter: Record<string, unknown> = { isActive: true };
+    if (q) filter['$or'] = [{ businessName: { $regex: q, $options: 'i' } }, { description: { $regex: q, $options: 'i' } }];
+    if (category) filter['category'] = category;
+    const [data, total] = await Promise.all([
+      this.vendorModel.find(filter).skip((page - 1) * limit).limit(limit).lean().select('businessName category serviceArea rating reviewCount'),
+      this.vendorModel.countDocuments(filter),
+    ]);
+    return { data, total };
+  }
+
+  async findVenues(q?: string, city?: string, page = 1, limit = 12): Promise<{ data: VenueProfile[]; total: number }> {
+    const filter: Record<string, unknown> = { isActive: true };
+    if (q) filter['$or'] = [{ name: { $regex: q, $options: 'i' } }, { 'address.city': { $regex: q, $options: 'i' } }];
+    if (city) filter['address.city'] = { $regex: city, $options: 'i' };
+    const [data, total] = await Promise.all([
+      this.venueModel.find(filter).skip((page - 1) * limit).limit(limit).lean().select('name address capacity rating reviewCount pricePerDay'),
+      this.venueModel.countDocuments(filter),
+    ]);
+    return { data, total };
+  }
 }

--- a/src/modules/emails/emails.service.ts
+++ b/src/modules/emails/emails.service.ts
@@ -149,6 +149,56 @@ export class EmailsService {
     await this.sendEmail(to, `Donnez votre avis — ${opts.eventTitle}`, html);
   }
 
+  // ── E-10 : Mise à jour réservation de lieu ──
+  async sendVenueBookingUpdate(
+    to: string,
+    opts: {
+      fullName: string;
+      venueName: string;
+      eventTitle: string;
+      status: 'confirmed' | 'refused';
+      message?: string;
+    },
+  ): Promise<void> {
+    const isConfirmed = opts.status === 'confirmed';
+    const subject = isConfirmed
+      ? `Lieu confirmé — ${opts.eventTitle}`
+      : `Lieu refusé — ${opts.eventTitle}`;
+
+    const html = this.baseTemplate(`
+      <h2 style="color:#0D1E35;margin:0 0 16px;">${isConfirmed ? 'Votre lieu a été confirmé !' : 'Votre demande de lieu a été refusée'}</h2>
+      <p style="color:#444;">Bonjour ${opts.fullName},</p>
+      <p style="color:#444;">Le lieu <strong>${opts.venueName}</strong> a <strong>${isConfirmed ? 'confirmé' : 'refusé'}</strong> votre demande pour l'événement <strong>${opts.eventTitle}</strong>.</p>
+      ${opts.message ? `<p style="color:#444;border-left:3px solid #1A7A5E;padding-left:12px;font-style:italic;">${opts.message}</p>` : ''}
+      ${this.ctaButton(`${this.frontendUrl}/tableau-de-bord`, 'Gérer mon événement')}
+    `);
+
+    await this.sendEmail(to, subject, html);
+  }
+
+  // ── E-12 : Email d'invitation ──
+  async sendInvitationEmail(
+    to: string,
+    opts: {
+      inviterName: string;
+      type: 'vendor' | 'venue';
+      eventTitle?: string;
+      invitationLink: string;
+    },
+  ): Promise<void> {
+    const typeLabel = opts.type === 'vendor' ? 'prestataire' : 'gestionnaire de salle';
+    const html = this.baseTemplate(`
+      <h2 style="color:#0D1E35;margin:0 0 16px;">Vous avez été invité sur Elintys !</h2>
+      <p style="color:#444;">Bonjour,</p>
+      <p style="color:#444;"><strong>${opts.inviterName}</strong> vous invite à rejoindre Elintys en tant que <strong>${typeLabel}</strong>${opts.eventTitle ? ` pour l'événement <strong>${opts.eventTitle}</strong>` : ''}.</p>
+      <p style="color:#444;">Elintys est la plateforme événementielle de référence au Québec. Créez votre profil et commencez à collaborer dès aujourd'hui.</p>
+      ${this.ctaButton(opts.invitationLink, 'Accepter l\'invitation')}
+      <p style="color:#888;font-size:12px;margin-top:24px;">Ce lien expire dans 7 jours. Si vous ne souhaitez pas rejoindre Elintys, ignorez ce message.</p>
+    `);
+
+    await this.sendEmail(to, `${opts.inviterName} vous invite sur Elintys`, html);
+  }
+
   // ── E-11 : Réinitialisation du mot de passe ──
   async sendPasswordReset(to: string, opts: { fullName: string; token: string }): Promise<void> {
     const link = `${this.frontendUrl}/reinitialiser-mot-de-passe?token=${opts.token}`;

--- a/src/modules/guests/dto/bulk-create-guest.dto.ts
+++ b/src/modules/guests/dto/bulk-create-guest.dto.ts
@@ -1,0 +1,14 @@
+import { Type } from 'class-transformer';
+import { ArrayMaxSize, ArrayMinSize, IsArray, ValidateNested } from 'class-validator';
+import { CreateGuestDto } from './create-guest.dto';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BulkCreateGuestDto {
+  @ApiProperty({ type: [CreateGuestDto], maxItems: 100 })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(100)
+  @ValidateNested({ each: true })
+  @Type(() => CreateGuestDto)
+  guests!: CreateGuestDto[];
+}

--- a/src/modules/guests/guests.controller.ts
+++ b/src/modules/guests/guests.controller.ts
@@ -3,6 +3,7 @@ import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiParam, ApiQuery }
 import { GuestsService } from './guests.service';
 import { CreateGuestDto } from './dto/create-guest.dto';
 import { UpdateGuestDto } from './dto/update-guest.dto';
+import { BulkCreateGuestDto } from './dto/bulk-create-guest.dto';
 import { CurrentUser, JwtPayload } from '../../shared/decorators/current-user.decorator';
 import { Roles, Role } from '../../shared/decorators/roles.decorator';
 
@@ -26,6 +27,18 @@ export class GuestsController {
     @Body() dto: CreateGuestDto,
   ) {
     return this.guestsService.create(eventId, user.sub, dto);
+  }
+
+  @Post('bulk')
+  @ApiOperation({ summary: 'Ajouter plusieurs invités en une seule requête (max 100)' })
+  @ApiParam({ name: 'eventId', description: 'MongoDB ObjectId de l\'événement' })
+  @ApiResponse({ status: 201, description: 'Invités ajoutés' })
+  bulkCreate(
+    @Param('eventId') eventId: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: BulkCreateGuestDto,
+  ) {
+    return this.guestsService.bulkCreate(eventId, user.sub, dto);
   }
 
   @Get()

--- a/src/modules/guests/guests.service.ts
+++ b/src/modules/guests/guests.service.ts
@@ -5,6 +5,7 @@ import { Guest, GuestDocument } from './guest.schema';
 import { Event, EventDocument } from '../events/event.schema';
 import { CreateGuestDto } from './dto/create-guest.dto';
 import { UpdateGuestDto } from './dto/update-guest.dto';
+import { BulkCreateGuestDto } from './dto/bulk-create-guest.dto';
 import { PaginatedResult } from '../../shared/interfaces/paginated-result.interface';
 
 @Injectable()
@@ -53,5 +54,16 @@ export class GuestsService {
     await this.assertEventOwner(eventId, userId);
     const result = await this.guestModel.findByIdAndDelete(id);
     if (!result) throw new NotFoundException('Invité introuvable.');
+  }
+
+  async bulkCreate(eventId: string, userId: string, dto: BulkCreateGuestDto): Promise<{ created: number }> {
+    await this.assertEventOwner(eventId, userId);
+    const docs = dto.guests.map((g) => ({
+      ...g,
+      event: new Types.ObjectId(eventId),
+      addedBy: new Types.ObjectId(userId),
+    }));
+    await this.guestModel.insertMany(docs, { ordered: false });
+    return { created: docs.length };
   }
 }

--- a/src/modules/invitations/invitations.module.ts
+++ b/src/modules/invitations/invitations.module.ts
@@ -3,11 +3,13 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { Invitation, InvitationSchema } from './invitation.schema';
 import { InvitationsService } from './invitations.service';
 import { InvitationsController } from './invitations.controller';
+import { User, UserSchema } from '../auth/user.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: Invitation.name, schema: InvitationSchema },
+      { name: User.name, schema: UserSchema },
     ]),
   ],
   providers: [InvitationsService],

--- a/src/modules/invitations/invitations.service.spec.ts
+++ b/src/modules/invitations/invitations.service.spec.ts
@@ -1,10 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getModelToken } from '@nestjs/mongoose';
+import { ConfigService } from '@nestjs/config';
 import { ConflictException, NotFoundException } from '@nestjs/common';
 import { Types } from 'mongoose';
 import { InvitationsService } from './invitations.service';
 import { Invitation, InvitationType } from './invitation.schema';
 import { ErrorCodes } from '../../shared/constants/error-codes';
+import { EmailsService } from '../emails/emails.service';
+import { User } from '../auth/user.schema';
 
 const mockInvitationModel = {
   create: jest.fn(),
@@ -23,6 +26,9 @@ describe('InvitationsService', () => {
       providers: [
         InvitationsService,
         { provide: getModelToken(Invitation.name), useValue: mockInvitationModel },
+        { provide: getModelToken(User.name), useValue: { findById: jest.fn().mockReturnValue({ lean: jest.fn().mockReturnThis(), select: jest.fn().mockResolvedValue({ fullName: 'Test User' }) }) } },
+        { provide: EmailsService, useValue: { sendInvitationEmail: jest.fn().mockResolvedValue(undefined) } },
+        { provide: ConfigService, useValue: { getOrThrow: jest.fn().mockReturnValue('http://localhost:3000') } },
       ],
     }).compile();
     service = module.get<InvitationsService>(InvitationsService);

--- a/src/modules/invitations/invitations.service.ts
+++ b/src/modules/invitations/invitations.service.ts
@@ -1,23 +1,31 @@
 import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
+import { ConfigService } from '@nestjs/config';
 import { FlattenMaps, Model, Types } from 'mongoose';
 import { Invitation, InvitationDocument, InvitationStatus } from './invitation.schema';
 import { CreateInvitationDto } from './dto/create-invitation.dto';
 import { ErrorCodes } from '../../shared/constants/error-codes';
+import { EmailsService } from '../emails/emails.service';
+import { User, UserDocument } from '../auth/user.schema';
 
 @Injectable()
 export class InvitationsService {
   constructor(
     @InjectModel(Invitation.name)
     private readonly invitationModel: Model<InvitationDocument>,
+    @InjectModel(User.name)
+    private readonly userModel: Model<UserDocument>,
+    private readonly emailsService: EmailsService,
+    private readonly configService: ConfigService,
   ) {}
 
   async sendInvitation(
     invitedById: string,
     dto: CreateInvitationDto,
   ): Promise<InvitationDocument> {
+    let invitation: InvitationDocument;
     try {
-      return await this.invitationModel.create({
+      invitation = await this.invitationModel.create({
         invitedBy: new Types.ObjectId(invitedById),
         email: dto.email,
         name: dto.name,
@@ -32,6 +40,23 @@ export class InvitationsService {
       }
       throw error;
     }
+
+    const inviter = await this.userModel
+      .findById(invitedById)
+      .lean()
+      .select('fullName');
+    const frontendUrl = this.configService.getOrThrow<string>('frontendUrl');
+    const invitationLink = `${frontendUrl}/invitation?token=${invitation.token}`;
+
+    this.emailsService
+      .sendInvitationEmail(dto.email, {
+        inviterName: inviter?.fullName ?? 'Un organisateur',
+        type: dto.type as 'vendor' | 'venue',
+        invitationLink,
+      })
+      .catch(() => undefined);
+
+    return invitation;
   }
 
   async getMyInvitations(

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -7,12 +7,20 @@ import {
   Patch,
   Query,
 } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { NotificationsService } from './notifications.service';
 import { CurrentUser, JwtPayload } from '../../shared/decorators/current-user.decorator';
 
+@ApiTags('Notifications')
 @Controller('notifications')
 export class NotificationsController {
   constructor(private readonly notificationsService: NotificationsService) {}
+
+  @Get('me/unread-count')
+  @ApiOperation({ summary: 'Nombre de notifications non lues' })
+  getUnreadCount(@CurrentUser() user: JwtPayload) {
+    return this.notificationsService.countUnread(user.sub);
+  }
 
   @Get('me')
   findMine(

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -63,4 +63,12 @@ export class NotificationsService {
       )
       .exec();
   }
+
+  async countUnread(userId: string): Promise<{ count: number }> {
+    const count = await this.notificationModel.countDocuments({
+      userId: new Types.ObjectId(userId),
+      read: false,
+    });
+    return { count };
+  }
 }

--- a/src/modules/vendors/vendors.module.ts
+++ b/src/modules/vendors/vendors.module.ts
@@ -3,12 +3,16 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { VendorsController } from './vendors.controller';
 import { VendorsService } from './vendors.service';
 import { VendorProfile, VendorProfileSchema, VendorRequest, VendorRequestSchema } from './vendor.schema';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
-  imports: [MongooseModule.forFeature([
-    { name: VendorProfile.name, schema: VendorProfileSchema },
-    { name: VendorRequest.name, schema: VendorRequestSchema },
-  ])],
+  imports: [
+    MongooseModule.forFeature([
+      { name: VendorProfile.name, schema: VendorProfileSchema },
+      { name: VendorRequest.name, schema: VendorRequestSchema },
+    ]),
+    NotificationsModule,
+  ],
   controllers: [VendorsController],
   providers: [VendorsService],
   exports: [VendorsService, MongooseModule],

--- a/src/modules/vendors/vendors.module.ts
+++ b/src/modules/vendors/vendors.module.ts
@@ -4,12 +4,16 @@ import { VendorsController } from './vendors.controller';
 import { VendorsService } from './vendors.service';
 import { VendorProfile, VendorProfileSchema, VendorRequest, VendorRequestSchema } from './vendor.schema';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { User, UserSchema } from '../auth/user.schema';
+import { Event, EventSchema } from '../events/event.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: VendorProfile.name, schema: VendorProfileSchema },
       { name: VendorRequest.name, schema: VendorRequestSchema },
+      { name: User.name, schema: UserSchema },
+      { name: Event.name, schema: EventSchema },
     ]),
     NotificationsModule,
   ],

--- a/src/modules/vendors/vendors.service.spec.ts
+++ b/src/modules/vendors/vendors.service.spec.ts
@@ -1,10 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException, ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { getModelToken } from '@nestjs/mongoose';
+import { ConfigService } from '@nestjs/config';
 import { Types } from 'mongoose';
 import { VendorsService } from './vendors.service';
 import { VendorProfile, VendorCategory, VendorRequest, VendorRequestSchema, VendorRequestStatus, VendorRequestSource } from './vendor.schema';
 import { NotificationsService } from '../notifications/notifications.service';
+import { EmailsService } from '../emails/emails.service';
+import { User } from '../auth/user.schema';
+import { Event } from '../events/event.schema';
 
 const makeChainable = (value: unknown) => {
   const chain: Record<string, unknown> = {};
@@ -82,7 +86,11 @@ describe('VendorsService', () => {
         VendorsService,
         { provide: getModelToken(VendorProfile.name), useValue: vendorModel },
         { provide: getModelToken(VendorRequest.name), useValue: vendorRequestModel },
+        { provide: getModelToken(User.name), useValue: { findById: jest.fn().mockReturnValue(makeChainable({ email: 'org@test.com', fullName: 'Org' })) } },
+        { provide: getModelToken(Event.name), useValue: { findById: jest.fn().mockReturnValue(makeChainable({ title: 'Test Event' })) } },
         { provide: NotificationsService, useValue: { create: jest.fn().mockResolvedValue(undefined) } },
+        { provide: EmailsService, useValue: { sendRequestAccepted: jest.fn().mockResolvedValue(undefined) } },
+        { provide: ConfigService, useValue: { getOrThrow: jest.fn().mockReturnValue('http://localhost:3000') } },
       ],
     }).compile();
 

--- a/src/modules/vendors/vendors.service.spec.ts
+++ b/src/modules/vendors/vendors.service.spec.ts
@@ -4,6 +4,7 @@ import { getModelToken } from '@nestjs/mongoose';
 import { Types } from 'mongoose';
 import { VendorsService } from './vendors.service';
 import { VendorProfile, VendorCategory, VendorRequest, VendorRequestSchema, VendorRequestStatus, VendorRequestSource } from './vendor.schema';
+import { NotificationsService } from '../notifications/notifications.service';
 
 const makeChainable = (value: unknown) => {
   const chain: Record<string, unknown> = {};
@@ -81,6 +82,7 @@ describe('VendorsService', () => {
         VendorsService,
         { provide: getModelToken(VendorProfile.name), useValue: vendorModel },
         { provide: getModelToken(VendorRequest.name), useValue: vendorRequestModel },
+        { provide: NotificationsService, useValue: { create: jest.fn().mockResolvedValue(undefined) } },
       ],
     }).compile();
 

--- a/src/modules/vendors/vendors.service.ts
+++ b/src/modules/vendors/vendors.service.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, ConflictException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
+import { ConfigService } from '@nestjs/config';
 import { Model, Types } from 'mongoose';
 import { VendorProfile, VendorProfileDocument, VendorRequest, VendorRequestDocument, VendorRequestSource, VendorRequestStatus } from './vendor.schema';
 import { CreateVendorDto } from './dto/create-vendor.dto';
@@ -11,13 +12,20 @@ import { PaginatedResult } from '../../shared/interfaces/paginated-result.interf
 import { ErrorCodes } from '../../shared/constants/error-codes';
 import { NotificationsService } from '../notifications/notifications.service';
 import { NotificationType } from '../notifications/notification.schema';
+import { EmailsService } from '../emails/emails.service';
+import { User, UserDocument } from '../auth/user.schema';
+import { Event, EventDocument } from '../events/event.schema';
 
 @Injectable()
 export class VendorsService {
   constructor(
     @InjectModel(VendorProfile.name) private readonly vendorModel: Model<VendorProfileDocument>,
     @InjectModel(VendorRequest.name) private readonly vendorRequestModel: Model<VendorRequestDocument>,
+    @InjectModel(User.name) private readonly userModel: Model<UserDocument>,
+    @InjectModel(Event.name) private readonly eventModel: Model<EventDocument>,
     private readonly notificationsService: NotificationsService,
+    private readonly emailsService: EmailsService,
+    private readonly configService: ConfigService,
   ) {}
 
   async create(userId: string, dto: CreateVendorDto): Promise<VendorProfile> {
@@ -88,7 +96,7 @@ export class VendorsService {
   }
 
   async respondToRequest(requestId: string, userId: string, dto: RespondVendorRequestDto): Promise<VendorRequest> {
-    const request = await this.vendorRequestModel.findById(requestId).lean().select('vendor status organizer');
+    const request = await this.vendorRequestModel.findById(requestId).lean().select('vendor status organizer event');
     if (!request) throw new NotFoundException(ErrorCodes.REQUEST_NOT_FOUND);
 
     // State check FIRST — cannot respond to non-pending requests regardless of who you are
@@ -115,6 +123,23 @@ export class VendorsService {
     this.notificationsService
       .create(organizerId, NotificationType.VENDOR_RESPONDED, { requestId, status: dto.status })
       .catch(() => undefined);
+
+    if (dto.status === VendorRequestStatus.ACCEPTED) {
+      const frontendUrl = this.configService.getOrThrow<string>('frontendUrl');
+      Promise.all([
+        this.userModel.findById(organizerId).lean().select('email fullName'),
+        this.eventModel.findById((request.event as Types.ObjectId).toString()).lean().select('title'),
+        this.vendorModel.findOne({ user: new Types.ObjectId(userId) }).lean().select('businessName'),
+      ]).then(([organizer, event, vendorProfile]) => {
+        if (!organizer || !event || !vendorProfile) return;
+        return this.emailsService.sendRequestAccepted(organizer.email, {
+          vendorName: vendorProfile.businessName,
+          organizerName: organizer.fullName,
+          eventTitle: event.title,
+          eventUrl: `${frontendUrl}/tableau-de-bord/evenements`,
+        });
+      }).catch(() => undefined);
+    }
 
     return updated!;
   }

--- a/src/modules/vendors/vendors.service.ts
+++ b/src/modules/vendors/vendors.service.ts
@@ -9,12 +9,15 @@ import { CreateVendorRequestDto } from './dto/create-request.dto';
 import { RespondVendorRequestDto } from './dto/respond-request.dto';
 import { PaginatedResult } from '../../shared/interfaces/paginated-result.interface';
 import { ErrorCodes } from '../../shared/constants/error-codes';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/notification.schema';
 
 @Injectable()
 export class VendorsService {
   constructor(
     @InjectModel(VendorProfile.name) private readonly vendorModel: Model<VendorProfileDocument>,
     @InjectModel(VendorRequest.name) private readonly vendorRequestModel: Model<VendorRequestDocument>,
+    private readonly notificationsService: NotificationsService,
   ) {}
 
   async create(userId: string, dto: CreateVendorDto): Promise<VendorProfile> {
@@ -85,7 +88,7 @@ export class VendorsService {
   }
 
   async respondToRequest(requestId: string, userId: string, dto: RespondVendorRequestDto): Promise<VendorRequest> {
-    const request = await this.vendorRequestModel.findById(requestId).lean().select('vendor status');
+    const request = await this.vendorRequestModel.findById(requestId).lean().select('vendor status organizer');
     if (!request) throw new NotFoundException(ErrorCodes.REQUEST_NOT_FOUND);
 
     // State check FIRST — cannot respond to non-pending requests regardless of who you are
@@ -107,6 +110,12 @@ export class VendorsService {
     const updated = await this.vendorRequestModel
       .findByIdAndUpdate(requestId, { status: dto.status, responseMessage: dto.responseMessage, respondedAt: new Date() }, { new: true })
       .lean().select('-__v');
+
+    const organizerId = (request.organizer as Types.ObjectId).toString();
+    this.notificationsService
+      .create(organizerId, NotificationType.VENDOR_RESPONDED, { requestId, status: dto.status })
+      .catch(() => undefined);
+
     return updated!;
   }
 

--- a/src/modules/venues/venues.module.ts
+++ b/src/modules/venues/venues.module.ts
@@ -4,12 +4,16 @@ import { VenuesController } from './venues.controller';
 import { VenuesService } from './venues.service';
 import { VenueProfile, VenueProfileSchema, VenueBooking, VenueBookingSchema } from './venue.schema';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { User, UserSchema } from '../auth/user.schema';
+import { Event, EventSchema } from '../events/event.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: VenueProfile.name, schema: VenueProfileSchema },
       { name: VenueBooking.name, schema: VenueBookingSchema },
+      { name: User.name, schema: UserSchema },
+      { name: Event.name, schema: EventSchema },
     ]),
     NotificationsModule,
   ],

--- a/src/modules/venues/venues.module.ts
+++ b/src/modules/venues/venues.module.ts
@@ -3,12 +3,16 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { VenuesController } from './venues.controller';
 import { VenuesService } from './venues.service';
 import { VenueProfile, VenueProfileSchema, VenueBooking, VenueBookingSchema } from './venue.schema';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
-  imports: [MongooseModule.forFeature([
-    { name: VenueProfile.name, schema: VenueProfileSchema },
-    { name: VenueBooking.name, schema: VenueBookingSchema },
-  ])],
+  imports: [
+    MongooseModule.forFeature([
+      { name: VenueProfile.name, schema: VenueProfileSchema },
+      { name: VenueBooking.name, schema: VenueBookingSchema },
+    ]),
+    NotificationsModule,
+  ],
   controllers: [VenuesController],
   providers: [VenuesService],
   exports: [VenuesService, MongooseModule],

--- a/src/modules/venues/venues.service.spec.ts
+++ b/src/modules/venues/venues.service.spec.ts
@@ -9,6 +9,7 @@ import { getModelToken } from '@nestjs/mongoose';
 import { Types } from 'mongoose';
 import { VenuesService } from './venues.service';
 import { VenueBooking, VenueBookingSchema, VenueBookingStatus, VenueProfile } from './venue.schema';
+import { NotificationsService } from '../notifications/notifications.service';
 
 const makeChainable = (value: unknown) => {
   const chain: Record<string, unknown> = {};
@@ -81,6 +82,7 @@ describe('VenuesService', () => {
         VenuesService,
         { provide: getModelToken(VenueProfile.name), useValue: venueModel },
         { provide: getModelToken(VenueBooking.name), useValue: venueBookingModel },
+        { provide: NotificationsService, useValue: { create: jest.fn().mockResolvedValue(undefined) } },
       ],
     }).compile();
 
@@ -234,7 +236,7 @@ describe('VenuesService', () => {
     it('devrait confirmer une réservation en attente', async () => {
       const venueProfileId = new Types.ObjectId(venueId);
       venueBookingModel.findById.mockReturnValue(
-        makeChainable({ status: VenueBookingStatus.PENDING, venue: venueProfileId }),
+        makeChainable({ status: VenueBookingStatus.PENDING, venue: venueProfileId, organizer: new Types.ObjectId(userId) }),
       );
       venueModel.findOne.mockReturnValue(makeChainable({ _id: venueProfileId }));
       const confirmed = mockBooking({ status: VenueBookingStatus.CONFIRMED });

--- a/src/modules/venues/venues.service.spec.ts
+++ b/src/modules/venues/venues.service.spec.ts
@@ -6,10 +6,14 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { getModelToken } from '@nestjs/mongoose';
+import { ConfigService } from '@nestjs/config';
 import { Types } from 'mongoose';
 import { VenuesService } from './venues.service';
 import { VenueBooking, VenueBookingSchema, VenueBookingStatus, VenueProfile } from './venue.schema';
 import { NotificationsService } from '../notifications/notifications.service';
+import { EmailsService } from '../emails/emails.service';
+import { User } from '../auth/user.schema';
+import { Event } from '../events/event.schema';
 
 const makeChainable = (value: unknown) => {
   const chain: Record<string, unknown> = {};
@@ -82,7 +86,11 @@ describe('VenuesService', () => {
         VenuesService,
         { provide: getModelToken(VenueProfile.name), useValue: venueModel },
         { provide: getModelToken(VenueBooking.name), useValue: venueBookingModel },
+        { provide: getModelToken(User.name), useValue: { findById: jest.fn().mockReturnValue(makeChainable({ email: 'org@test.com', fullName: 'Org' })) } },
+        { provide: getModelToken(Event.name), useValue: { findById: jest.fn().mockReturnValue(makeChainable({ title: 'Test Event' })) } },
         { provide: NotificationsService, useValue: { create: jest.fn().mockResolvedValue(undefined) } },
+        { provide: EmailsService, useValue: { sendVenueBookingUpdate: jest.fn().mockResolvedValue(undefined) } },
+        { provide: ConfigService, useValue: { getOrThrow: jest.fn().mockReturnValue('http://localhost:3000') } },
       ],
     }).compile();
 
@@ -236,7 +244,7 @@ describe('VenuesService', () => {
     it('devrait confirmer une réservation en attente', async () => {
       const venueProfileId = new Types.ObjectId(venueId);
       venueBookingModel.findById.mockReturnValue(
-        makeChainable({ status: VenueBookingStatus.PENDING, venue: venueProfileId, organizer: new Types.ObjectId(userId) }),
+        makeChainable({ status: VenueBookingStatus.PENDING, venue: venueProfileId, organizer: new Types.ObjectId(userId), event: new Types.ObjectId(eventId) }),
       );
       venueModel.findOne.mockReturnValue(makeChainable({ _id: venueProfileId }));
       const confirmed = mockBooking({ status: VenueBookingStatus.CONFIRMED });

--- a/src/modules/venues/venues.service.ts
+++ b/src/modules/venues/venues.service.ts
@@ -6,6 +6,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
+import { ConfigService } from '@nestjs/config';
 import { Model, Types } from 'mongoose';
 import {
   VenueBooking,
@@ -22,13 +23,20 @@ import { PaginatedResult } from '../../shared/interfaces/paginated-result.interf
 import { ErrorCodes } from '../../shared/constants/error-codes';
 import { NotificationsService } from '../notifications/notifications.service';
 import { NotificationType } from '../notifications/notification.schema';
+import { EmailsService } from '../emails/emails.service';
+import { User, UserDocument } from '../auth/user.schema';
+import { Event, EventDocument } from '../events/event.schema';
 
 @Injectable()
 export class VenuesService {
   constructor(
     @InjectModel(VenueProfile.name) private readonly venueModel: Model<VenueProfileDocument>,
     @InjectModel(VenueBooking.name) private readonly venueBookingModel: Model<VenueBookingDocument>,
+    @InjectModel(User.name) private readonly userModel: Model<UserDocument>,
+    @InjectModel(Event.name) private readonly eventModel: Model<EventDocument>,
     private readonly notificationsService: NotificationsService,
+    private readonly emailsService: EmailsService,
+    private readonly configService: ConfigService,
   ) {}
 
   async create(userId: string, dto: CreateVenueDto): Promise<VenueProfile> {
@@ -96,7 +104,7 @@ export class VenuesService {
   }
 
   async respondToBooking(bookingId: string, userId: string, dto: RespondVenueBookingDto): Promise<VenueBooking> {
-    const booking = await this.venueBookingModel.findById(bookingId).lean().select('venue status organizer');
+    const booking = await this.venueBookingModel.findById(bookingId).lean().select('venue status organizer event');
     if (!booking) throw new NotFoundException(ErrorCodes.BOOKING_NOT_FOUND);
 
     if (booking.status !== VenueBookingStatus.PENDING) {
@@ -121,6 +129,22 @@ export class VenuesService {
     this.notificationsService
       .create(organizerId, NotificationType.VENUE_CONFIRMED, { bookingId, status: dto.status })
       .catch(() => undefined);
+
+    const emailStatus = dto.status === VenueBookingStatus.CONFIRMED ? 'confirmed' : 'refused';
+    Promise.all([
+      this.userModel.findById(organizerId).lean().select('email fullName'),
+      this.eventModel.findById((booking.event as Types.ObjectId).toString()).lean().select('title'),
+      this.venueModel.findById((booking.venue as Types.ObjectId).toString()).lean().select('name'),
+    ]).then(([organizer, event, venue]) => {
+      if (!organizer || !event || !venue) return;
+      return this.emailsService.sendVenueBookingUpdate(organizer.email, {
+        fullName: organizer.fullName,
+        venueName: venue.name,
+        eventTitle: event.title,
+        status: emailStatus,
+        message: dto.responseMessage,
+      });
+    }).catch(() => undefined);
 
     return updated!;
   }

--- a/src/modules/venues/venues.service.ts
+++ b/src/modules/venues/venues.service.ts
@@ -20,12 +20,15 @@ import { CreateVenueBookingDto } from './dto/create-booking.dto';
 import { RespondVenueBookingDto } from './dto/respond-booking.dto';
 import { PaginatedResult } from '../../shared/interfaces/paginated-result.interface';
 import { ErrorCodes } from '../../shared/constants/error-codes';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/notification.schema';
 
 @Injectable()
 export class VenuesService {
   constructor(
     @InjectModel(VenueProfile.name) private readonly venueModel: Model<VenueProfileDocument>,
     @InjectModel(VenueBooking.name) private readonly venueBookingModel: Model<VenueBookingDocument>,
+    private readonly notificationsService: NotificationsService,
   ) {}
 
   async create(userId: string, dto: CreateVenueDto): Promise<VenueProfile> {
@@ -93,7 +96,7 @@ export class VenuesService {
   }
 
   async respondToBooking(bookingId: string, userId: string, dto: RespondVenueBookingDto): Promise<VenueBooking> {
-    const booking = await this.venueBookingModel.findById(bookingId).lean().select('venue status');
+    const booking = await this.venueBookingModel.findById(bookingId).lean().select('venue status organizer');
     if (!booking) throw new NotFoundException(ErrorCodes.BOOKING_NOT_FOUND);
 
     if (booking.status !== VenueBookingStatus.PENDING) {
@@ -113,6 +116,12 @@ export class VenuesService {
       )
       .lean()
       .select('-__v');
+
+    const organizerId = (booking.organizer as Types.ObjectId).toString();
+    this.notificationsService
+      .create(organizerId, NotificationType.VENUE_CONFIRMED, { bookingId, status: dto.status })
+      .catch(() => undefined);
+
     return updated!;
   }
 

--- a/src/modules/waitlist/dto/create-waitlist-entry.dto.ts
+++ b/src/modules/waitlist/dto/create-waitlist-entry.dto.ts
@@ -1,0 +1,31 @@
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsEmail, IsEnum, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { WaitlistRole, WaitlistSource } from '../waitlist.schema';
+
+export class CreateWaitlistEntryDto {
+  @ApiProperty({ example: 'Marie' })
+  @Transform(({ value }) => value?.trim())
+  @IsString()
+  @MinLength(1)
+  @MaxLength(50)
+  firstName!: string;
+
+  @ApiProperty({ example: 'marie@example.com' })
+  @Transform(({ value }) => value?.trim().toLowerCase())
+  @IsEmail()
+  email!: string;
+
+  @ApiProperty({ enum: WaitlistRole, example: WaitlistRole.ORGANISATEUR })
+  @IsEnum(WaitlistRole)
+  role!: WaitlistRole;
+
+  @ApiProperty({ enum: WaitlistSource, example: WaitlistSource.CTA })
+  @IsEnum(WaitlistSource)
+  source!: WaitlistSource;
+
+  @ApiProperty({ example: false, required: false })
+  @IsOptional()
+  @IsBoolean()
+  consentMarketing?: boolean;
+}

--- a/src/modules/waitlist/waitlist.controller.ts
+++ b/src/modules/waitlist/waitlist.controller.ts
@@ -1,0 +1,31 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Public } from '../../shared/decorators/public.decorator';
+import { WaitlistService } from './waitlist.service';
+import { CreateWaitlistEntryDto } from './dto/create-waitlist-entry.dto';
+
+@ApiTags('Waitlist')
+@Controller('waitlist')
+export class WaitlistController {
+  constructor(private readonly waitlistService: WaitlistService) {}
+
+  @Public()
+  @Throttle({ default: { limit: 5, ttl: 10 * 60_000 } })
+  @Post()
+  @ApiOperation({ summary: "Rejoindre la liste d'attente" })
+  @ApiResponse({ status: 201, description: 'Inscription confirmée' })
+  async join(@Body() dto: CreateWaitlistEntryDto) {
+    const { alreadyExists } = await this.waitlistService.join(dto);
+    return { success: true, alreadyExists };
+  }
+
+  @Public()
+  @Get('count')
+  @ApiOperation({ summary: "Nombre d'inscrits à la liste d'attente" })
+  @ApiResponse({ status: 200, description: 'Total des inscrits' })
+  async count() {
+    const count = await this.waitlistService.count();
+    return { count };
+  }
+}

--- a/src/modules/waitlist/waitlist.module.ts
+++ b/src/modules/waitlist/waitlist.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { WaitlistController } from './waitlist.controller';
+import { WaitlistService } from './waitlist.service';
+import { WaitlistEntry, WaitlistEntrySchema } from './waitlist.schema';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: WaitlistEntry.name, schema: WaitlistEntrySchema }])],
+  controllers: [WaitlistController],
+  providers: [WaitlistService],
+  exports: [WaitlistService],
+})
+export class WaitlistModule {}

--- a/src/modules/waitlist/waitlist.schema.ts
+++ b/src/modules/waitlist/waitlist.schema.ts
@@ -1,0 +1,37 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+
+export type WaitlistEntryDocument = HydratedDocument<WaitlistEntry>;
+
+export enum WaitlistRole {
+  ORGANISATEUR = 'organisateur',
+  PRESTATAIRE = 'prestataire',
+  GESTIONNAIRE = 'gestionnaire',
+  VISITEUR = 'visiteur',
+}
+
+export enum WaitlistSource {
+  HERO = 'hero',
+  CTA = 'cta',
+}
+
+@Schema({ timestamps: true })
+export class WaitlistEntry {
+  @Prop({ required: true, trim: true, maxlength: 50 })
+  firstName!: string;
+
+  @Prop({ required: true, trim: true, lowercase: true })
+  email!: string;
+
+  @Prop({ enum: Object.values(WaitlistRole), required: true })
+  role!: WaitlistRole;
+
+  @Prop({ enum: Object.values(WaitlistSource), required: true })
+  source!: WaitlistSource;
+
+  @Prop({ required: true, default: false })
+  consentMarketing!: boolean;
+}
+
+export const WaitlistEntrySchema = SchemaFactory.createForClass(WaitlistEntry);
+WaitlistEntrySchema.index({ email: 1 }, { unique: true });

--- a/src/modules/waitlist/waitlist.service.ts
+++ b/src/modules/waitlist/waitlist.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { WaitlistEntry, WaitlistEntryDocument } from './waitlist.schema';
+import { CreateWaitlistEntryDto } from './dto/create-waitlist-entry.dto';
+
+@Injectable()
+export class WaitlistService {
+  constructor(
+    @InjectModel(WaitlistEntry.name) private readonly waitlistModel: Model<WaitlistEntryDocument>,
+  ) {}
+
+  async join(dto: CreateWaitlistEntryDto): Promise<{ alreadyExists: boolean }> {
+    const existing = await this.waitlistModel.findOne({ email: dto.email }).lean().select('_id');
+    if (existing) {
+      return { alreadyExists: true };
+    }
+
+    await this.waitlistModel.create({
+      firstName: dto.firstName,
+      email: dto.email,
+      role: dto.role,
+      source: dto.source,
+      consentMarketing: dto.consentMarketing ?? false,
+    });
+
+    return { alreadyExists: false };
+  }
+
+  async count(): Promise<number> {
+    return this.waitlistModel.estimatedDocumentCount();
+  }
+}


### PR DESCRIPTION
## Plan C — API

### T1: Notifications in-app sur réponses vendor/venue
- NotificationsService injecté dans VendorsService et VenuesService
- VENDOR_RESPONDED déclenché dans respondToRequest
- VENUE_CONFIRMED déclenché dans respondToBooking
- Fire-and-forget (.catch) — ne bloque pas le flux principal

### T2: Emails déclenchés automatiquement
- sendVenueBookingUpdate (confirmed/refused) dans EmailsService
- sendInvitationEmail dans EmailsService
- InvitationsService déclenche sendInvitationEmail après création (fire-and-forget)
- VendorsService déclenche sendRequestAccepted si ACCEPTED (fire-and-forget)

### T3: APIs complémentaires
- GuestsService.bulkCreate + POST /events/:id/guests/bulk (max 100)
- NotificationsService.countUnread + GET /notifications/me/unread-count
- DiscoveryService.findEvents, findVendors, findVenues (paginé, filtres q/city/category)

## Tests
237/237 passent — 0 erreur TypeScript

🤖 Generated with [Claude Code](https://claude.com/claude-code)