### PR TITLE
feat(api): confirmation email on waitlist signup

### DIFF
--- a/src/modules/emails/emails.service.spec.ts
+++ b/src/modules/emails/emails.service.spec.ts
@@ -141,4 +141,26 @@ describe('EmailsService', () => {
       expect(callArg.html).toContain('Jean Tremblay');
     });
   });
+
+  // ── sendWaitlistConfirmation ──
+  describe('sendWaitlistConfirmation', () => {
+    it("devrait envoyer un courriel de confirmation avec les points forts du rôle choisi", async () => {
+      mockResendSend.mockResolvedValue({ data: { id: 'email-id-ghi' }, error: null });
+
+      await service.sendWaitlistConfirmation('user@exemple.ca', {
+        firstName: 'Marie',
+        role: 'prestataire',
+      });
+
+      expect(mockResendSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'user@exemple.ca',
+          subject: 'Vous êtes sur la liste Elintys !',
+          html: expect.stringContaining('Marie'),
+        }),
+      );
+      const callArg: { html: string } = mockResendSend.mock.calls[0][0] as { html: string };
+      expect(callArg.html).toContain('bouche-à-oreille');
+    });
+  });
 });

--- a/src/modules/emails/emails.service.ts
+++ b/src/modules/emails/emails.service.ts
@@ -213,6 +213,50 @@ export class EmailsService {
     await this.sendEmail(to, 'Réinitialisation de votre mot de passe — Elintys', html);
   }
 
+  // ── E-13 : Confirmation d'inscription à la liste d'attente ──
+  async sendWaitlistConfirmation(to: string, opts: {
+    firstName: string;
+    role: 'organisateur' | 'prestataire' | 'gestionnaire' | 'visiteur';
+  }): Promise<void> {
+    const highlightsByRole: Record<typeof opts.role, string[]> = {
+      organisateur: [
+        'Créez vos événements sans jongler entre plusieurs outils',
+        'Retrouvez lieux, prestataires, billets et invités dans un seul tableau de bord',
+        'Passez moins de temps à synchroniser, plus de temps à organiser',
+      ],
+      prestataire: [
+        'Soyez visible au bon moment, sans dépendre seulement du bouche-à-oreille',
+        'Recevez des demandes liées à de vrais événements',
+        "Rejoignez un écosystème pensé pour connecter les talents à la demande réelle",
+      ],
+      gestionnaire: [
+        'Recevez des demandes structurées : date, capacité, contexte',
+        'Présentez votre espace aux organisateurs qui le cherchent activement',
+        'Gagnez du temps dès le premier échange',
+      ],
+      visiteur: [
+        "Découvrez les événements locaux autrement",
+        "Recevez les premières nouvelles sur l'ouverture de la plateforme",
+        'Faites partie des tout premiers inscrits',
+      ],
+    };
+
+    const highlights = highlightsByRole[opts.role]
+      .map((item) => `<li style="color:#444;line-height:1.7;">${item}</li>`)
+      .join('');
+
+    const html = this.baseTemplate(`
+      <h2 style="color:#0D1E35;margin:0 0 16px;">Vous êtes sur la liste !</h2>
+      <p style="color:#444;">Bonjour ${opts.firstName},</p>
+      <p style="color:#444;">Merci de rejoindre la liste d'attente Elintys. On vous contactera dès que les portes s'ouvrent.</p>
+      <p style="color:#0D1E35;font-weight:600;margin-top:24px;">Ce qui vous attend :</p>
+      <ul style="padding-left:20px;">${highlights}</ul>
+      ${this.ctaButton(this.frontendUrl, 'Découvrir Elintys')}
+    `);
+
+    await this.sendEmail(to, "Vous êtes sur la liste Elintys !", html);
+  }
+
   private baseTemplate(content: string): string {
     return `
 <!DOCTYPE html>

--- a/src/modules/waitlist/waitlist.service.ts
+++ b/src/modules/waitlist/waitlist.service.ts
@@ -3,11 +3,13 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { WaitlistEntry, WaitlistEntryDocument } from './waitlist.schema';
 import { CreateWaitlistEntryDto } from './dto/create-waitlist-entry.dto';
+import { EmailsService } from '../emails/emails.service';
 
 @Injectable()
 export class WaitlistService {
   constructor(
     @InjectModel(WaitlistEntry.name) private readonly waitlistModel: Model<WaitlistEntryDocument>,
+    private readonly emailsService: EmailsService,
   ) {}
 
   async join(dto: CreateWaitlistEntryDto): Promise<{ alreadyExists: boolean }> {
@@ -23,6 +25,10 @@ export class WaitlistService {
       source: dto.source,
       consentMarketing: dto.consentMarketing ?? false,
     });
+
+    this.emailsService
+      .sendWaitlistConfirmation(dto.email, { firstName: dto.firstName, role: dto.role })
+      .catch(() => undefined);
 
     return { alreadyExists: false };
   }


### PR DESCRIPTION
## Summary
- Adds `EmailsService.sendWaitlistConfirmation` (role-aware highlights, French copy, same base template as other transactional emails)
- Wires it into `WaitlistService.join()` as a fire-and-forget send so a Resend failure never blocks the signup response
- Adds a spec test for the new email method

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/modules/emails src/modules/waitlist`
- [x] `npm run build`