### PR TITLE
Fix Render development build

### DIFF
--- a/docs/render-development.md
+++ b/docs/render-development.md
@@ -4,7 +4,8 @@ Le fichier `render.yaml` décrit le service `elintys-api-dev` :
 
 - dépôt `NoeKen/Elintys-api`, branche `dev`;
 - déploiement automatique à chaque commit;
-- build reproductible avec `npm ci && npm run build`;
+- build reproductible sous Node.js 22 avec installation des outils de
+  compilation, puis suppression des dépendances de développement;
 - démarrage avec `npm run start:prod`;
 - contrôle de santé sur `/api/v1/health`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "22.x"
       }
     },
     "node_modules/@angular-devkit/core": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "typescript": "^5.9.3"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": "22.x"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/render.yaml
+++ b/render.yaml
@@ -6,7 +6,7 @@ services:
     branch: dev
     plan: free
     region: ohio
-    buildCommand: npm ci && npm run build
+    buildCommand: npm ci --include=dev && npm run build && npm prune --omit=dev
     startCommand: npm run start:prod
     healthCheckPath: /api/v1/health
     autoDeployTrigger: commit


### PR DESCRIPTION
## Résumé
- installe explicitement les dépendances de compilation sur Render
- compile puis retire les dépendances de développement
- fixe le runtime sur Node.js 22 LTS

## Validation
- build NestJS réussi
- health controller test réussi
- audit des dépendances de production: 0 vulnérabilité