### PR TITLE
feat: isolate dev data and expose observable catalogs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 PORT=3001
 API_HOST=0.0.0.0
 NODE_ENV=development
+# Environnement métier et données: dev ou prod (indépendant de NODE_ENV)
+ELINTYS_ENV=dev
 ENABLE_SWAGGER=false
 
 # MongoDB Atlas
@@ -25,6 +27,7 @@ EMAIL_FROM=Elintys <noreply@elintys.ca>
 CLOUDINARY_CLOUD_NAME=
 CLOUDINARY_API_KEY=
 CLOUDINARY_API_SECRET=
+# Dérivé strictement de ELINTYS_ENV : Elintys/dev/... ou Elintys/prod/...
 
 # Anthropic (Phase 2)
 ANTHROPIC_API_KEY=
@@ -32,3 +35,5 @@ ANTHROPIC_API_KEY=
 # Frontend
 FRONTEND_URL=http://localhost:3000
 CORS_ORIGINS=
+# Omettre en local. Développement hébergé: .dev.elintys.app; production: .elintys.com
+COOKIE_DOMAIN=

--- a/docs/auth-cookies-and-observability.md
+++ b/docs/auth-cookies-and-observability.md
@@ -1,0 +1,61 @@
+# Cookies d'authentification et observabilité HTTP
+
+## Domaines apparentés
+
+L'API conserve les jetons dans des cookies `HttpOnly`, `SameSite=Lax` et
+`Secure` dès qu'elle est déployée (`NODE_ENV=production`) ou qu'un domaine de
+cookie est configuré.
+
+| Environnement | Frontend | API | `COOKIE_DOMAIN` |
+| --- | --- | --- | --- |
+| Développement hébergé | `https://app.dev.elintys.app` | `https://api.dev.elintys.app` | `.dev.elintys.app` |
+| Production | `https://app.elintys.com` | `https://api.elintys.com` | `.elintys.com` |
+
+`COOKIE_DOMAIN` doit commencer par un point, être un nom DNS valide et être un
+domaine parent de l'hôte défini par `FRONTEND_URL`. L'API refuse de démarrer si
+une valeur configurée ne respecte pas ces contraintes. `ELINTYS_ENV=dev`
+impose `.dev.elintys.app`, tandis que `ELINTYS_ENV=prod` impose `.elintys.com`.
+Les domaines enregistrables distincts empêchent un hôte de développement de
+recevoir ou d'émettre les cookies de production.
+Dans un runtime déployé (`NODE_ENV=production`), `ELINTYS_ENV` et
+`COOKIE_DOMAIN` sont obligatoires. En local, la variable de domaine doit être
+omise pour utiliser un cookie limité à l'hôte.
+
+La suppression des cookies réutilise exactement le même domaine, chemin et les
+mêmes attributs de sécurité que leur création.
+
+## Protection des requêtes d'écriture
+
+CORS est limité aux origines exactes définies par `FRONTEND_URL` et
+`CORS_ORIGINS`. En complément, les requêtes navigateur `POST`, `PUT`, `PATCH`
+et `DELETE` dont l'en-tête `Origin` ne correspond pas à cette liste sont
+refusées avec un statut 403. Ce contrôle évite qu'un site tiers déclenche une
+écriture authentifiée sans pouvoir lire la réponse. Les lectures, les
+pré-requêtes `OPTIONS` et les clients serveur ou natifs sans en-tête `Origin`
+restent autorisés.
+
+## Corrélation et logs réseau
+
+L'API accepte un en-tête `x-request-id` composé de 1 à 128 caractères
+alphanumériques ou parmi `._:-`. Une valeur absente ou invalide est remplacée
+par un UUID généré côté API. Le même identifiant est renvoyé dans la réponse.
+
+Chaque réponse terminée produit une ligne JSON sur la sortie standard :
+
+```json
+{
+  "event": "http_request",
+  "service": "elintys-api",
+  "environment": "dev",
+  "requestId": "01J...",
+  "method": "GET",
+  "route": "/api/v1/events",
+  "status": 200,
+  "durationMs": 42.17
+}
+```
+
+Les erreurs serveur produisent un événement `http_exception` corrélé. Les logs
+n'incluent ni corps, ni paramètres de requête, ni chaîne de requête, ni
+en-têtes, ni cookies, ni jetons. Render collecte ces lignes depuis la sortie
+standard; aucune collection MongoDB n'est utilisée pour les logs réseau.

--- a/docs/development-seed.md
+++ b/docs/development-seed.md
@@ -1,0 +1,36 @@
+# Données de démonstration — développement
+
+La commande suivante ajoute ou met à jour les données de démonstration sans
+supprimer les données existantes :
+
+```bash
+npm run seed:dev
+```
+
+Elle refuse de démarrer sauf si :
+
+- `ELINTYS_ENV=dev` (garde-fou métier indépendant de `NODE_ENV`);
+- `MONGODB_URI` cible une base nommée exactement `elintys-dev`.
+
+Elle est idempotente : les utilisateurs sont identifiés par courriel, les
+profils par utilisateur et les événements par slug. Elle ne fait aucun
+`deleteMany`, `dropDatabase` ou remplacement global.
+
+## Comptes de démonstration
+
+Ces identifiants sont publics et réservés exclusivement à la base dev :
+
+| Rôle | Courriel |
+| --- | --- |
+| Organisateur | `organisateur@demo.elintys.com` |
+| Prestataire | `prestataire@demo.elintys.com` |
+| Gestionnaire de lieu | `gestionnaire@demo.elintys.com` |
+| Participant | `participant@demo.elintys.com` |
+
+Mot de passe commun : `Elintys-Dev-2026!`
+
+Ne jamais réutiliser ce mot de passe pour un compte réel. Le seed garantit au
+moins dix prestataires actifs, dix lieux actifs et dix événements publics,
+ainsi qu'un brouillon, afin de tester les catalogues et le tableau de bord.
+Chaque profil possède un utilisateur de démonstration vérifié; la collection
+des utilisateurs contient donc plus de dix entrées.

--- a/docs/media-storage-audit.md
+++ b/docs/media-storage-audit.md
@@ -56,11 +56,11 @@ Les six anciennes couvertures pointent vers Unsplash. Elles ne possèdent donc n
 
 Pour garantir un remplacement sans perte, la couverture est versionnée sous :
 
-`elintys/events/{eventId}/cover/{uuid}`
+`Elintys/{dev|prod}/events/{eventId}/cover/{uuid}`
 
 La galerie utilise :
 
-`elintys/events/{eventId}/gallery/{uuid}`
+`Elintys/{dev|prod}/events/{eventId}/gallery/{uuid}`
 
 Le segment logique `cover` reste stable, mais l’actif final reçoit une version unique. Cette variante est nécessaire pour respecter l’ordre sûr « upload → base → suppression de l’ancien » : un écrasement du même `publicId` modifierait l’ancien actif avant la confirmation MongoDB.
 

--- a/docs/media-storage.md
+++ b/docs/media-storage.md
@@ -49,9 +49,12 @@ Le backend peut démarrer sans Cloudinary afin de ne pas bloquer les fonctions n
 ## Organisation Cloudinary
 
 ```text
-elintys/events/{eventId}/cover/{uuid}
-elintys/events/{eventId}/gallery/{uuid}
+Elintys/{dev|prod}/events/{eventId}/cover/{uuid}
+Elintys/{dev|prod}/events/{eventId}/gallery/{uuid}
 ```
+
+`ELINTYS_ENV` détermine strictement le segment `dev` ou `prod`. Le service
+refuse l’upload si l’environnement applicatif est absent ou invalide.
 
 La couverture est versionnée pour respecter l’ordre :
 
@@ -89,7 +92,7 @@ files: <binary[]>
 DELETE /api/v1/events/:eventId/gallery
 Content-Type: application/json
 
-{ "publicId": "elintys/events/..." }
+{ "publicId": "Elintys/dev/events/..." }
 ```
 
 La réponse commune est :
@@ -98,7 +101,7 @@ La réponse commune est :
 {
   "coverImage": {
     "url": "https://res.cloudinary.com/...",
-    "publicId": "elintys/events/.../cover/...",
+    "publicId": "Elintys/dev/events/.../cover/...",
     "width": 1920,
     "height": 1080
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,14 +120,14 @@
       }
     },
     "node_modules/@angular-devkit/schematics-cli": {
-      "version": "19.2.24",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-19.2.24.tgz",
-      "integrity": "sha512-bsStZQG67J1HBqTmWxtIcobvgrn32L4UOdL7hGyOru5VxDWPNA8pRnDYavT3hnJeBkJYPoQIw8u7Dm0ecoQprw==",
+      "version": "19.2.27",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-19.2.27.tgz",
+      "integrity": "sha512-wHYH6SVXVykhLzovUHtYor3Nl4SpIiITi7r9DQDaKYUD4hpRBx25W6N9eGuakT9Vd5tV/x6wmvQFWQZQwFB7eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.24",
-        "@angular-devkit/schematics": "19.2.24",
+        "@angular-devkit/core": "19.2.27",
+        "@angular-devkit/schematics": "19.2.27",
         "@inquirer/prompts": "7.3.2",
         "ansi-colors": "4.1.3",
         "symbol-observable": "4.0.0",
@@ -135,6 +135,53 @@
       },
       "bin": {
         "schematics": "bin/schematics.js"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular-devkit/schematics-cli/node_modules/@angular-devkit/core": {
+      "version": "19.2.27",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.27.tgz",
+      "integrity": "sha512-3amNzoCVSKd7ah6l6lBQL4onwwJvqvam7FMoQBILrxtW5LB5ezh8gMSPuA4zJjKjoRzf9uoWdlzqv/84I52xZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.18.0",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.4",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular-devkit/schematics-cli/node_modules/@angular-devkit/schematics": {
+      "version": "19.2.27",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.27.tgz",
+      "integrity": "sha512-/PZmyAlb2NGWPikRRuiWLdfHQd8Wrx6lX4HqvTcaDhlU43M3T0ud4PH2T3QDp7BzHYY92xtD8iPxX2asg67G1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/core": "19.2.27",
+        "jsonc-parser": "3.3.1",
+        "magic-string": "0.30.17",
+        "ora": "5.4.1",
+        "rxjs": "7.8.1"
       },
       "engines": {
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
@@ -170,6 +217,16 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular-devkit/schematics-cli/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/rxjs": {
@@ -805,9 +862,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -855,9 +912,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -867,7 +924,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -879,9 +936,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -903,9 +960,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -944,9 +1001,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2232,9 +2289,9 @@
       "license": "MIT"
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2468,15 +2525,15 @@
       }
     },
     "node_modules/@nestjs/cli": {
-      "version": "11.0.21",
-      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.21.tgz",
-      "integrity": "sha512-F8mV0Sj/zVEouzR3NxBuJy08YHTUOmC5Xdcx3qIIaJWzrm8Vw86CHkhkaPBJ5ewRMHPDCShPmhsfwhpCcjts3A==",
+      "version": "11.0.24",
+      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.24.tgz",
+      "integrity": "sha512-aIHxQLSYtXShifA3zwWIeznEsZnNa3Iz2QRykFj+sl9IcbERBHr5nH87FRgywM+He3NxoF5WazHfR8FsmVeWxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.24",
-        "@angular-devkit/schematics": "19.2.24",
-        "@angular-devkit/schematics-cli": "19.2.24",
+        "@angular-devkit/core": "19.2.27",
+        "@angular-devkit/schematics": "19.2.27",
+        "@angular-devkit/schematics-cli": "19.2.27",
         "@inquirer/prompts": "7.10.1",
         "@nestjs/schematics": "^11.0.1",
         "ansis": "4.2.0",
@@ -2490,7 +2547,7 @@
         "tsconfig-paths": "4.2.0",
         "tsconfig-paths-webpack-plugin": "4.2.0",
         "typescript": "5.9.3",
-        "webpack": "5.106.0",
+        "webpack": "5.106.2",
         "webpack-node-externals": "3.0.0"
       },
       "bin": {
@@ -2510,6 +2567,63 @@
         "@swc/core": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/cli/node_modules/@angular-devkit/core": {
+      "version": "19.2.27",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.27.tgz",
+      "integrity": "sha512-3amNzoCVSKd7ah6l6lBQL4onwwJvqvam7FMoQBILrxtW5LB5ezh8gMSPuA4zJjKjoRzf9uoWdlzqv/84I52xZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.18.0",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.4",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/cli/node_modules/@angular-devkit/schematics": {
+      "version": "19.2.27",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.27.tgz",
+      "integrity": "sha512-/PZmyAlb2NGWPikRRuiWLdfHQd8Wrx6lX4HqvTcaDhlU43M3T0ud4PH2T3QDp7BzHYY92xtD8iPxX2asg67G1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/core": "19.2.27",
+        "jsonc-parser": "3.3.1",
+        "magic-string": "0.30.17",
+        "ora": "5.4.1",
+        "rxjs": "7.8.1"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@nestjs/cli/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@nestjs/common": {
@@ -4376,9 +4490,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5428,9 +5542,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5439,8 +5553,8 @@
         "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -5542,9 +5656,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6069,9 +6183,9 @@
       "license": "MIT"
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6974,9 +7088,9 @@
       "license": "MIT"
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7323,9 +7437,9 @@
       "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9917,9 +10031,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10052,9 +10166,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.9",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
-      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
+      "version": "29.4.12",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
+      "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10064,7 +10178,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.4",
+        "semver": "^7.8.5",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -10506,9 +10620,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.106.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.0.tgz",
-      "integrity": "sha512-Pkx5joZ9RrdgO5LBkyX1L2ZAJeK/Taz3vqZ9CbcP0wS5LEMx5QkKsEwLl29QJfihZ+DKRBFldzy1O30pJ1MDpA==",
+      "version": "5.106.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
+      "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10528,9 +10642,8 @@
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
+        "mime-db": "^1.54.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
@@ -10614,6 +10727,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/webpack/node_modules/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:cov": "jest --coverage",
     "test:verbose": "jest --verbose",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "media:migrate": "ts-node src/scripts/migrate-event-media.ts"
+    "media:migrate": "ts-node src/scripts/migrate-event-media.ts",
+    "seed:dev": "ts-node src/scripts/seed-development.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.1.19",

--- a/render.yaml
+++ b/render.yaml
@@ -13,6 +13,8 @@ services:
     envVars:
       - key: NODE_ENV
         value: production
+      - key: ELINTYS_ENV
+        value: dev
       - key: API_HOST
         value: 0.0.0.0
       - key: ENABLE_SWAGGER
@@ -43,5 +45,7 @@ services:
         sync: false
       - key: FRONTEND_URL
         sync: false
+      - key: COOKIE_DOMAIN
+        value: .dev.elintys.app
       - key: CORS_ORIGINS
         sync: false

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,29 +1,52 @@
-export default () => ({
-  port: parseInt(process.env.PORT ?? '3001', 10),
-  nodeEnv: process.env.NODE_ENV ?? 'development',
-  jwt: {
-    secret: process.env.JWT_SECRET,
-    expiresIn: process.env.JWT_EXPIRES_IN ?? '15m',
-    refreshSecret: process.env.JWT_REFRESH_SECRET,
-    refreshExpiresIn: process.env.JWT_REFRESH_EXPIRES_IN ?? '7d',
-  },
-  stripe: {
-    secretKey: process.env.STRIPE_SECRET_KEY,
-    webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
-  },
-  resend: {
-    apiKey: process.env.RESEND_API_KEY,
-  },
-  email: {
-    from: process.env.EMAIL_FROM ?? 'Elintys <no-reply@elintys.com>',
-  },
-  cloudinary: {
-    cloudName: process.env.CLOUDINARY_CLOUD_NAME,
-    apiKey: process.env.CLOUDINARY_API_KEY,
-    apiSecret: process.env.CLOUDINARY_API_SECRET,
-  },
-  anthropic: {
-    apiKey: process.env.ANTHROPIC_API_KEY,
-  },
-  frontendUrl: process.env.FRONTEND_URL ?? 'http://localhost:3000',
-});
+import { resolveCookieDomain } from './cookie-domain';
+import { resolveElintysEnvironment } from './elintys-environment';
+
+export default () => {
+  const nodeEnv = process.env.NODE_ENV ?? 'development';
+  const elintysEnv = resolveElintysEnvironment(
+    process.env.ELINTYS_ENV,
+    nodeEnv,
+  );
+  const frontendUrl = process.env.FRONTEND_URL ?? 'http://localhost:3000';
+  const cookieDomain = resolveCookieDomain(
+    process.env.COOKIE_DOMAIN,
+    frontendUrl,
+    elintysEnv,
+    nodeEnv === 'production',
+  );
+
+  return {
+    port: parseInt(process.env.PORT ?? '3001', 10),
+    nodeEnv,
+    elintysEnv,
+    jwt: {
+      secret: process.env.JWT_SECRET,
+      expiresIn: process.env.JWT_EXPIRES_IN ?? '15m',
+      refreshSecret: process.env.JWT_REFRESH_SECRET,
+      refreshExpiresIn: process.env.JWT_REFRESH_EXPIRES_IN ?? '7d',
+    },
+    stripe: {
+      secretKey: process.env.STRIPE_SECRET_KEY,
+      webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+    },
+    resend: {
+      apiKey: process.env.RESEND_API_KEY,
+    },
+    email: {
+      from: process.env.EMAIL_FROM ?? 'Elintys <no-reply@elintys.com>',
+    },
+    cloudinary: {
+      cloudName: process.env.CLOUDINARY_CLOUD_NAME,
+      apiKey: process.env.CLOUDINARY_API_KEY,
+      apiSecret: process.env.CLOUDINARY_API_SECRET,
+    },
+    anthropic: {
+      apiKey: process.env.ANTHROPIC_API_KEY,
+    },
+    frontendUrl,
+    authCookie: {
+      domain: cookieDomain,
+      secure: nodeEnv === 'production' || cookieDomain !== undefined,
+    },
+  };
+};

--- a/src/config/cookie-domain.spec.ts
+++ b/src/config/cookie-domain.spec.ts
@@ -1,0 +1,81 @@
+import { resolveCookieDomain } from './cookie-domain';
+
+describe('resolveCookieDomain', () => {
+  it('normalise un domaine parent valide', () => {
+    expect(
+      resolveCookieDomain(
+        '  .DEV.ELINTYS.APP ',
+        'https://app.dev.elintys.app',
+        'dev',
+      ),
+    ).toBe('.dev.elintys.app');
+  });
+
+  it('accepte le domaine parent de production', () => {
+    expect(
+      resolveCookieDomain('.elintys.com', 'https://app.elintys.com', 'prod'),
+    ).toBe('.elintys.com');
+  });
+
+  it('laisse les cookies host-only en développement local', () => {
+    expect(
+      resolveCookieDomain(undefined, 'http://localhost:3100', 'dev'),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    'dev.elintys.app',
+    'https://dev.elintys.app',
+    '.dev.elintys.app/path',
+    '.dev.elintys.app:443',
+    '.*.elintys.com',
+    '.localhost',
+    '.127.0.0.1',
+  ])('rejette le format de domaine non sécurisé %s', (domain) => {
+    expect(() =>
+      resolveCookieDomain(domain, 'https://app.dev.elintys.app', 'dev'),
+    ).toThrow('COOKIE_DOMAIN');
+  });
+
+  it("rejette un domaine qui n'est pas parent du frontend", () => {
+    expect(() =>
+      resolveCookieDomain('.elintys.com', 'https://example.com', 'prod'),
+    ).toThrow('parent domain');
+  });
+
+  it('rejette les faux suffixes apparentés', () => {
+    expect(() =>
+      resolveCookieDomain(
+        '.elintys.com',
+        'https://app.elintys.com.evil.test',
+        'prod',
+      ),
+    ).toThrow('parent domain');
+  });
+
+  it('empêche le développement de partager les cookies avec la production', () => {
+    expect(() =>
+      resolveCookieDomain(
+        '.elintys.app',
+        'https://app.dev.elintys.app',
+        'dev',
+      ),
+    ).toThrow('ELINTYS_ENV=dev');
+  });
+
+  it('empêche la production d’utiliser le domaine de développement', () => {
+    expect(() =>
+      resolveCookieDomain(
+        '.dev.elintys.app',
+        'https://app.dev.elintys.app',
+        'prod',
+      ),
+    ).toThrow('ELINTYS_ENV=prod');
+  });
+
+  it('exige un domaine de cookie dans un environnement déployé', () => {
+    expect(() =>
+      resolveCookieDomain(undefined, 'https://app.dev.elintys.app', 'dev', true),
+    ).toThrow('required');
+  });
+});

--- a/src/config/cookie-domain.ts
+++ b/src/config/cookie-domain.ts
@@ -1,0 +1,74 @@
+import { ElintysEnvironment } from './elintys-environment';
+
+const COOKIE_DOMAIN_PATTERN =
+  /^\.(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+function getFrontendHostname(frontendUrl: string): string {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(frontendUrl);
+  } catch {
+    throw new Error('FRONTEND_URL must be an absolute HTTP(S) URL.');
+  }
+
+  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    throw new Error('FRONTEND_URL must use HTTP or HTTPS.');
+  }
+
+  return parsedUrl.hostname.toLowerCase();
+}
+
+/**
+ * Validates and normalizes the optional parent domain used by authentication
+ * cookies. A leading dot is required intentionally so a host-only typo cannot
+ * silently break sessions between the app and API sibling subdomains.
+ */
+export function resolveCookieDomain(
+  rawDomain: string | undefined,
+  frontendUrl: string,
+  environment: ElintysEnvironment,
+  requireDomain = false,
+): string | undefined {
+  const trimmedDomain = rawDomain?.trim();
+
+  if (!trimmedDomain) {
+    if (requireDomain) {
+      throw new Error(
+        'COOKIE_DOMAIN is required for a deployed environment.',
+      );
+    }
+
+    return undefined;
+  }
+
+  const domain = trimmedDomain.toLowerCase();
+
+  if (!COOKIE_DOMAIN_PATTERN.test(domain)) {
+    throw new Error(
+      'COOKIE_DOMAIN must be a parent DNS domain with a leading dot (for example .dev.elintys.app).',
+    );
+  }
+
+  const frontendHostname = getFrontendHostname(frontendUrl);
+  const bareDomain = domain.slice(1);
+  const isRelatedDomain =
+    frontendHostname === bareDomain || frontendHostname.endsWith(domain);
+
+  if (!isRelatedDomain) {
+    throw new Error(
+      'COOKIE_DOMAIN must be a parent domain of the FRONTEND_URL hostname.',
+    );
+  }
+
+  const expectedDomain =
+    environment === 'dev' ? '.dev.elintys.app' : '.elintys.com';
+
+  if (domain !== expectedDomain) {
+    throw new Error(
+      `COOKIE_DOMAIN must be ${expectedDomain} when ELINTYS_ENV=${environment}.`,
+    );
+  }
+
+  return domain;
+}

--- a/src/config/elintys-environment.spec.ts
+++ b/src/config/elintys-environment.spec.ts
@@ -1,0 +1,31 @@
+import { resolveElintysEnvironment } from './elintys-environment';
+
+describe('resolveElintysEnvironment', () => {
+  it.each(['dev', 'prod'] as const)(
+    'accepte la valeur explicite %s',
+    (environment) => {
+      expect(resolveElintysEnvironment(environment, 'production')).toBe(
+        environment,
+      );
+    },
+  );
+
+  it.each(['development', 'test'])(
+    'utilise dev par défaut uniquement pour NODE_ENV=%s',
+    (nodeEnv) => {
+      expect(resolveElintysEnvironment(undefined, nodeEnv)).toBe('dev');
+    },
+  );
+
+  it('exige une valeur explicite avec NODE_ENV=production', () => {
+    expect(() =>
+      resolveElintysEnvironment(undefined, 'production'),
+    ).toThrow('ELINTYS_ENV');
+  });
+
+  it('rejette toute autre valeur', () => {
+    expect(() =>
+      resolveElintysEnvironment('staging', 'production'),
+    ).toThrow('ELINTYS_ENV');
+  });
+});

--- a/src/config/elintys-environment.ts
+++ b/src/config/elintys-environment.ts
@@ -1,0 +1,18 @@
+export type ElintysEnvironment = 'dev' | 'prod';
+
+export function resolveElintysEnvironment(
+  rawEnvironment: string | undefined,
+  nodeEnv: string,
+): ElintysEnvironment {
+  if (rawEnvironment === 'dev' || rawEnvironment === 'prod') {
+    return rawEnvironment;
+  }
+
+  if (!rawEnvironment && (nodeEnv === 'development' || nodeEnv === 'test')) {
+    return 'dev';
+  }
+
+  throw new Error(
+    'ELINTYS_ENV must be explicitly set to "dev" or "prod" for a deployed environment.',
+  );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,11 @@ import { JwtAuthGuard } from './shared/guards/jwt-auth.guard';
 import { RolesGuard } from './shared/guards/roles.guard';
 import { AllExceptionsFilter } from './shared/filters/http-exception.filter';
 import { ConfigService } from '@nestjs/config';
+import { createRequestObservabilityMiddleware } from './shared/middleware/request-observability.middleware';
+import {
+  createTrustedOriginMiddleware,
+  normalizeAllowedOrigins,
+} from './shared/middleware/trusted-origin.middleware';
 
 type CorsOriginCallback = (error: Error | null, allow?: boolean) => void;
 
@@ -21,18 +26,21 @@ async function bootstrap(): Promise<void> {
   const port = configService.getOrThrow<number>('port');
   const apiHost = process.env.API_HOST ?? '0.0.0.0';
   const nodeEnv = configService.get<string>('nodeEnv');
+  const elintysEnv = configService.getOrThrow<string>('elintysEnv');
   const enableSwagger = process.env.ENABLE_SWAGGER === 'true' || nodeEnv !== 'production';
 
   app.use(helmet());
-  app.use(cookieParser());
-
-  const corsOrigins = [
+  app.use(createRequestObservabilityMiddleware(elintysEnv));
+  const corsOrigins = normalizeAllowedOrigins([
     frontendUrl,
     ...(process.env.CORS_ORIGINS ?? '')
       .split(',')
       .map((origin) => origin.trim())
       .filter(Boolean),
-  ];
+  ]);
+
+  app.use(cookieParser());
+  app.use(createTrustedOriginMiddleware(corsOrigins));
 
   app.enableCors({
     origin: (origin: string | undefined, callback: CorsOriginCallback) => {
@@ -52,6 +60,7 @@ async function bootstrap(): Promise<void> {
       return callback(new Error(`CORS origin not allowed: ${origin}`), false);
     },
     credentials: true,
+    exposedHeaders: ['x-request-id'],
   });
 
   app.setGlobalPrefix('api/v1');

--- a/src/modules/auth/auth.controller.spec.ts
+++ b/src/modules/auth/auth.controller.spec.ts
@@ -22,8 +22,12 @@ const mockAuthService = {
 
 const mockConfigService = {
   getOrThrow: jest.fn().mockImplementation((key: string) => {
-    if (key === 'nodeEnv') return 'test';
+    if (key === 'authCookie.secure') return true;
     return 'value';
+  }),
+  get: jest.fn().mockImplementation((key: string) => {
+    if (key === 'authCookie.domain') return '.dev.elintys.com';
+    return undefined;
   }),
 };
 
@@ -67,6 +71,17 @@ describe('AuthController', () => {
       expect(mockAuthService.register).toHaveBeenCalledWith(dto);
       expect(res.cookie).toHaveBeenCalledWith('access_token', 'access_token', expect.any(Object));
       expect(res.cookie).toHaveBeenCalledWith('refresh_token', 'refresh_token', expect.any(Object));
+      expect(res.cookie).toHaveBeenCalledWith(
+        'access_token',
+        'access_token',
+        expect.objectContaining({
+          domain: '.dev.elintys.com',
+          httpOnly: true,
+          path: '/',
+          sameSite: 'lax',
+          secure: true,
+        }),
+      );
       expect(result).toHaveProperty('user');
       expect(result).not.toHaveProperty('accessToken');
       expect(result).not.toHaveProperty('refreshToken');
@@ -154,8 +169,15 @@ describe('AuthController', () => {
       const result = await controller.logout((req as unknown) as Request, res as Response);
 
       expect(mockAuthService.logoutFromCookie).toHaveBeenCalledWith('old_cookie_token');
-      expect(res.clearCookie).toHaveBeenCalledWith('access_token', { path: '/' });
-      expect(res.clearCookie).toHaveBeenCalledWith('refresh_token', { path: '/' });
+      const expectedOptions = {
+        domain: '.dev.elintys.com',
+        httpOnly: true,
+        path: '/',
+        sameSite: 'lax',
+        secure: true,
+      };
+      expect(res.clearCookie).toHaveBeenCalledWith('access_token', expectedOptions);
+      expect(res.clearCookie).toHaveBeenCalledWith('refresh_token', expectedOptions);
       expect(result).toEqual({ message: 'Déconnecté avec succès' });
     });
 
@@ -167,8 +189,14 @@ describe('AuthController', () => {
       await controller.logout((req as unknown) as Request, res as Response);
 
       expect(mockAuthService.logoutFromCookie).toHaveBeenCalledWith(undefined);
-      expect(res.clearCookie).toHaveBeenCalledWith('access_token', { path: '/' });
-      expect(res.clearCookie).toHaveBeenCalledWith('refresh_token', { path: '/' });
+      expect(res.clearCookie).toHaveBeenCalledWith(
+        'access_token',
+        expect.objectContaining({ domain: '.dev.elintys.com', path: '/' }),
+      );
+      expect(res.clearCookie).toHaveBeenCalledWith(
+        'refresh_token',
+        expect.objectContaining({ domain: '.dev.elintys.com', path: '/' }),
+      );
     });
   });
 

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -12,7 +12,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Request, Response } from 'express';
+import { CookieOptions, Request, Response } from 'express';
 import { ApiTags, ApiOperation, ApiResponse, ApiBody, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
@@ -33,27 +33,29 @@ export class AuthController {
     private readonly configService: ConfigService,
   ) {}
 
-  private get refreshCookieOptions() {
+  private get sharedCookieOptions(): CookieOptions {
+    const domain = this.configService.get<string>('authCookie.domain');
+
     return {
       httpOnly: true,
-      secure: this.configService.getOrThrow<string>('nodeEnv') === 'production',
-      sameSite: this.configService.getOrThrow<string>('nodeEnv') === 'production'
-        ? 'none' as const
-        : 'lax' as const,
-      maxAge: 7 * 24 * 60 * 60 * 1000,
+      secure: this.configService.getOrThrow<boolean>('authCookie.secure'),
+      sameSite: 'lax',
+      ...(domain ? { domain } : {}),
       path: '/',
     };
   }
 
-  private get accessCookieOptions() {
+  private get refreshCookieOptions(): CookieOptions {
     return {
-      httpOnly: true,
-      secure: this.configService.getOrThrow<string>('nodeEnv') === 'production',
-      sameSite: this.configService.getOrThrow<string>('nodeEnv') === 'production'
-        ? 'none' as const
-        : 'lax' as const,
+      ...this.sharedCookieOptions,
+      maxAge: 7 * 24 * 60 * 60 * 1000,
+    };
+  }
+
+  private get accessCookieOptions(): CookieOptions {
+    return {
+      ...this.sharedCookieOptions,
       maxAge: 15 * 60 * 1000,
-      path: '/',
     };
   }
 
@@ -156,8 +158,8 @@ export class AuthController {
   ): Promise<{ message: string }> {
     const cookieToken = (req.cookies as Record<string, string>)?.refresh_token;
     await this.authService.logoutFromCookie(cookieToken);
-    res.clearCookie('access_token', { path: '/' });
-    res.clearCookie('refresh_token', { path: '/' });
+    res.clearCookie('access_token', this.sharedCookieOptions);
+    res.clearCookie('refresh_token', this.sharedCookieOptions);
     return { message: 'Déconnecté avec succès' };
   }
 

--- a/src/modules/events/dto/delete-event-gallery-image.dto.ts
+++ b/src/modules/events/dto/delete-event-gallery-image.dto.ts
@@ -3,7 +3,7 @@ import { IsString, MaxLength, MinLength } from 'class-validator';
 
 export class DeleteEventGalleryImageDto {
   @ApiProperty({
-    example: 'elintys/events/64f0.../gallery/550e8400-e29b-41d4-a716-446655440000',
+    example: 'Elintys/dev/events/64f0.../gallery/550e8400-e29b-41d4-a716-446655440000',
   })
   @IsString()
   @MinLength(1)

--- a/src/modules/events/dto/query-event.dto.ts
+++ b/src/modules/events/dto/query-event.dto.ts
@@ -1,7 +1,7 @@
-import { IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { IsEnum, IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { EventStatus, EventVisibility } from '../event.schema';
+import { EventStatus, EventType, EventVisibility } from '../event.schema';
 
 export class QueryEventDto {
   @ApiPropertyOptional({ default: 1, minimum: 1, description: 'Numéro de page' })
@@ -33,5 +33,14 @@ export class QueryEventDto {
   @IsOptional()
   @Transform(({ value }: { value: string }) => value?.trim())
   @IsString()
+  @MaxLength(100)
   city?: string;
+
+  @ApiPropertyOptional({
+    enum: EventType,
+    description: 'Filtrer par catégorie publique',
+  })
+  @IsOptional()
+  @IsEnum(EventType)
+  category?: EventType;
 }

--- a/src/modules/events/event-media.service.spec.ts
+++ b/src/modules/events/event-media.service.spec.ts
@@ -15,6 +15,7 @@ import {
 } from '../media/media-storage.interface';
 import type { MediaImage } from '../media/media-image.schema';
 import { MediaCleanupService } from '../media/media-cleanup.service';
+import { ConfigService } from '@nestjs/config';
 
 function chain<T>(value: T) {
   const result = {
@@ -53,13 +54,13 @@ describe('EventMediaService', () => {
   } as Express.Multer.File;
   const uploadedCover: MediaImage = {
     url: 'https://res.cloudinary.com/demo/image/upload/cover.jpg',
-    publicId: `elintys/events/${eventId}/cover/new-cover`,
+    publicId: `Elintys/dev/events/${eventId}/cover/new-cover`,
     width: 1920,
     height: 1080,
   };
   const existingCover: MediaImage = {
     url: 'https://res.cloudinary.com/demo/image/upload/old.jpg',
-    publicId: `elintys/events/${eventId}/cover/old-cover`,
+    publicId: `Elintys/dev/events/${eventId}/cover/old-cover`,
     width: 1920,
     height: 1080,
   };
@@ -90,6 +91,10 @@ describe('EventMediaService', () => {
         { provide: MEDIA_STORAGE, useValue: storage },
         { provide: ImageFileValidationService, useValue: validator },
         { provide: MediaCleanupService, useValue: mediaCleanup },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue('dev') },
+        },
       ],
     }).compile();
     service = module.get(EventMediaService);
@@ -119,10 +124,40 @@ describe('EventMediaService', () => {
     expect(storage.uploadImage).toHaveBeenCalledWith({
       buffer: Buffer.from('normalized'),
       publicId: expect.stringMatching(
-        new RegExp(`^elintys/events/${eventId}/cover/`),
+        new RegExp(`^Elintys/dev/events/${eventId}/cover/`),
       ),
     });
     expect(result.coverImage).toEqual(uploadedCover);
+  });
+
+  it('isole les uploads de production sous Elintys/prod', async () => {
+    const productionService = new EventMediaService(
+      eventModel as never,
+      storage,
+      validator as never,
+      mediaCleanup as never,
+      { get: jest.fn().mockReturnValue('prod') } as unknown as ConfigService,
+    );
+    eventModel.findById.mockReturnValue(chain(ownedEvent()));
+    storage.uploadImage.mockResolvedValue({
+      ...uploadedCover,
+      publicId: `Elintys/prod/events/${eventId}/cover/new-cover`,
+    });
+    eventModel.findOneAndUpdate.mockReturnValue(
+      chain({
+        coverImage: uploadedCover,
+        gallery: [],
+      }),
+    );
+
+    await productionService.uploadCover(eventId, organizerId, file);
+
+    expect(storage.uploadImage).toHaveBeenCalledWith({
+      buffer: Buffer.from('normalized'),
+      publicId: expect.stringMatching(
+        new RegExp(`^Elintys/prod/events/${eventId}/cover/`),
+      ),
+    });
   });
 
   it('supprime l’ancienne couverture seulement après la persistance', async () => {
@@ -176,7 +211,7 @@ describe('EventMediaService', () => {
         ownedEvent({
           gallery: Array.from({ length: 10 }, (_, index) => ({
             ...uploadedCover,
-            publicId: `elintys/events/${eventId}/gallery/${index}`,
+            publicId: `Elintys/dev/events/${eventId}/gallery/${index}`,
           })),
         }),
       ),
@@ -192,11 +227,11 @@ describe('EventMediaService', () => {
     eventModel.findById.mockReturnValue(chain(ownedEvent()));
     const first = {
       ...uploadedCover,
-      publicId: `elintys/events/${eventId}/gallery/first`,
+      publicId: `Elintys/dev/events/${eventId}/gallery/first`,
     };
     const second = {
       ...uploadedCover,
-      publicId: `elintys/events/${eventId}/gallery/second`,
+      publicId: `Elintys/dev/events/${eventId}/gallery/second`,
     };
     storage.uploadImage
       .mockResolvedValueOnce(first)
@@ -223,7 +258,7 @@ describe('EventMediaService', () => {
     eventModel.findById.mockReturnValue(chain(ownedEvent()));
     const galleryImage = {
       ...uploadedCover,
-      publicId: `elintys/events/${eventId}/gallery/first`,
+      publicId: `Elintys/dev/events/${eventId}/gallery/first`,
     };
     storage.uploadImage
       .mockResolvedValueOnce(galleryImage)
@@ -244,7 +279,7 @@ describe('EventMediaService', () => {
     const result = await service.deleteGalleryImage(
       eventId,
       organizerId,
-      `elintys/events/${eventId}/gallery/absent`,
+      `Elintys/dev/events/${eventId}/gallery/absent`,
     );
 
     expect(result.gallery).toEqual([]);
@@ -255,7 +290,7 @@ describe('EventMediaService', () => {
   it('retire la référence MongoDB avant de supprimer l’actif distant', async () => {
     const image = {
       ...uploadedCover,
-      publicId: `elintys/events/${eventId}/gallery/image`,
+      publicId: `Elintys/dev/events/${eventId}/gallery/image`,
     };
     eventModel.findById.mockReturnValue(
       chain(ownedEvent({ gallery: [image] })),
@@ -274,7 +309,7 @@ describe('EventMediaService', () => {
   it('conserve le nouvel état si le nettoyage Cloudinary échoue après suppression', async () => {
     const image = {
       ...uploadedCover,
-      publicId: `elintys/events/${eventId}/gallery/image`,
+      publicId: `Elintys/dev/events/${eventId}/gallery/image`,
     };
     eventModel.findById.mockReturnValue(
       chain(ownedEvent({ gallery: [image] })),

--- a/src/modules/events/event-media.service.ts
+++ b/src/modules/events/event-media.service.ts
@@ -9,6 +9,7 @@ import {
 import { InjectModel } from '@nestjs/mongoose';
 import { randomUUID } from 'node:crypto';
 import { Model, Types } from 'mongoose';
+import { ConfigService } from '@nestjs/config';
 import { ErrorCodes } from '../../shared/constants/error-codes';
 import { MEDIA_MAX_GALLERY_IMAGES } from '../media/media.constants';
 import {
@@ -22,6 +23,7 @@ import {
   MediaStorage,
 } from '../media/media-storage.interface';
 import { Event, EventDocument } from './event.schema';
+import { getMediaRootPrefix } from '../media/media-environment';
 
 export interface EventMediaState {
   coverImage: MediaImage | string | null;
@@ -35,6 +37,7 @@ type EventMediaSnapshot = Pick<Event, 'coverImage' | 'gallery' | 'organizer'> & 
 @Injectable()
 export class EventMediaService {
   private readonly logger = new Logger(EventMediaService.name);
+  private readonly mediaRootPrefix: string;
 
   constructor(
     @InjectModel(Event.name)
@@ -43,7 +46,12 @@ export class EventMediaService {
     private readonly mediaStorage: MediaStorage,
     private readonly imageValidation: ImageFileValidationService,
     private readonly mediaCleanup: MediaCleanupService,
-  ) {}
+    configService: ConfigService,
+  ) {
+    this.mediaRootPrefix = getMediaRootPrefix(
+      configService.get<'dev' | 'prod'>('elintysEnv'),
+    );
+  }
 
   async uploadCover(
     eventId: string,
@@ -272,7 +280,7 @@ export class EventMediaService {
     eventId: string,
     kind: 'cover' | 'gallery',
   ): string {
-    return `elintys/events/${eventId}/${kind}/${randomUUID()}`;
+    return `${this.mediaRootPrefix}/events/${eventId}/${kind}/${randomUUID()}`;
   }
 
   private isOwnedPublicId(
@@ -280,7 +288,9 @@ export class EventMediaService {
     publicId: string,
     kind: 'cover' | 'gallery',
   ): boolean {
-    return publicId.startsWith(`elintys/events/${eventId}/${kind}/`);
+    return publicId.startsWith(
+      `${this.mediaRootPrefix}/events/${eventId}/${kind}/`,
+    );
   }
 
   private toMediaState(

--- a/src/modules/events/event.schema.ts
+++ b/src/modules/events/event.schema.ts
@@ -206,3 +206,4 @@ EventSchema.index({ slug: 1 }, { unique: true, sparse: true });
 EventSchema.index({ organizer: 1, status: 1 });
 EventSchema.index({ startDate: 1 });
 EventSchema.index({ 'location.city': 1, status: 1 });
+EventSchema.index({ eventType: 1, status: 1, visibility: 1 });

--- a/src/modules/events/events.controller.spec.ts
+++ b/src/modules/events/events.controller.spec.ts
@@ -6,6 +6,7 @@ import { EventMediaService } from './event-media.service';
 const mockEventsService = {
   create: jest.fn(),
   findAll: jest.fn(),
+  getPublicCategoryCounts: jest.fn(),
   findOne: jest.fn(),
   update: jest.fn(),
   remove: jest.fn(),
@@ -59,6 +60,19 @@ describe('EventsController', () => {
       await controller.findAll(query as never);
 
       expect(mockEventsService.findAll).toHaveBeenCalledWith(query);
+    });
+  });
+
+  describe('getCategoryCounts', () => {
+    it('délègue l’agrégation à eventsService', async () => {
+      mockEventsService.getPublicCategoryCounts.mockResolvedValue({
+        data: [],
+        total: 0,
+      });
+
+      await controller.getCategoryCounts();
+
+      expect(mockEventsService.getPublicCategoryCounts).toHaveBeenCalled();
     });
   });
 
@@ -127,13 +141,13 @@ describe('EventsController', () => {
       await controller.deleteGalleryImage(
         'event-id',
         mockUser as never,
-        { publicId: 'elintys/events/event-id/gallery/image' },
+        { publicId: 'Elintys/dev/events/event-id/gallery/image' },
       );
 
       expect(mockEventMediaService.deleteGalleryImage).toHaveBeenCalledWith(
         'event-id',
         mockUser.sub,
-        'elintys/events/event-id/gallery/image',
+        'Elintys/dev/events/event-id/gallery/image',
       );
     });
   });

--- a/src/modules/events/events.controller.ts
+++ b/src/modules/events/events.controller.ts
@@ -75,6 +75,14 @@ export class EventsController {
     return this.eventsService.findAll(query);
   }
 
+  @Public()
+  @Get('categories')
+  @ApiOperation({ summary: 'Compter les événements publics par catégorie' })
+  @ApiResponse({ status: 200, description: 'Agrégation des catégories publiques' })
+  getCategoryCounts() {
+    return this.eventsService.getPublicCategoryCounts();
+  }
+
   @Get('my')
   @Roles(Role.ORGANISATEUR, Role.ADMIN)
   @ApiOperation({ summary: 'Mes événements (organisateur connecté)' })

--- a/src/modules/events/events.service.spec.ts
+++ b/src/modules/events/events.service.spec.ts
@@ -3,7 +3,7 @@ import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { getModelToken } from '@nestjs/mongoose';
 import { Types } from 'mongoose';
 import { EventsService } from './events.service';
-import { Event, EventStatus } from './event.schema';
+import { Event, EventStatus, EventType } from './event.schema';
 import { EventMediaService } from './event-media.service';
 
 const makeChainable = (value: unknown) => {
@@ -45,6 +45,7 @@ describe('EventsService', () => {
       findByIdAndUpdate: jest.fn(),
       findByIdAndDelete: jest.fn(),
       countDocuments: jest.fn(),
+      aggregate: jest.fn(),
       create: jest.fn(),
     };
 
@@ -52,6 +53,7 @@ describe('EventsService', () => {
     eventModel.findById.mockReturnValue(makeChainable(mockEvent()));
     eventModel.findOne.mockReturnValue(makeChainable(null));
     eventModel.countDocuments.mockResolvedValue(1);
+    eventModel.aggregate.mockResolvedValue([]);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -114,6 +116,42 @@ describe('EventsService', () => {
 
       expect(eventModel.find).toHaveBeenCalledWith(
         expect.objectContaining({ 'location.city': expect.any(Object) }),
+      );
+    });
+
+    it('filtre par catégorie publique si fournie', async () => {
+      await service.findAll({
+        page: 1,
+        limit: 10,
+        category: EventType.CONFERENCE,
+      });
+
+      expect(eventModel.find).toHaveBeenCalledWith(
+        expect.objectContaining({ eventType: EventType.CONFERENCE }),
+      );
+    });
+  });
+
+  describe('getPublicCategoryCounts', () => {
+    it('agrège uniquement les événements publics publiés', async () => {
+      eventModel.aggregate.mockResolvedValue([
+        { _id: EventType.CONFERENCE, count: 3 },
+      ]);
+      eventModel.countDocuments.mockResolvedValue(3);
+
+      await expect(service.getPublicCategoryCounts()).resolves.toEqual({
+        data: [{ category: EventType.CONFERENCE, count: 3 }],
+        total: 3,
+      });
+      expect(eventModel.aggregate).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          {
+            $match: expect.objectContaining({
+              status: EventStatus.PUBLISHED,
+              visibility: 'public',
+            }),
+          },
+        ]),
       );
     });
   });

--- a/src/modules/events/events.service.ts
+++ b/src/modules/events/events.service.ts
@@ -19,6 +19,7 @@ import { QueryEventDto } from './dto/query-event.dto';
 import { PaginatedResult } from '../../shared/interfaces/paginated-result.interface';
 import { ErrorCodes } from '../../shared/constants/error-codes';
 import { EventMediaService } from './event-media.service';
+import { escapeRegExp } from '../../shared/utils/escape-regexp';
 
 @Injectable()
 export class EventsService {
@@ -57,14 +58,20 @@ export class EventsService {
   }
 
   async findAll(query: QueryEventDto): Promise<PaginatedResult<Event>> {
-    const { page = 1, limit = 20, city } = query;
+    const { page = 1, limit = 20, city, category } = query;
     const skip = (page - 1) * limit;
 
     const filter: Record<string, unknown> = {
       status: EventStatus.PUBLISHED,
       visibility: EventVisibility.PUBLIC,
     };
-    if (city) filter['location.city'] = { $regex: city, $options: 'i' };
+    if (city) {
+      filter['location.city'] = {
+        $regex: escapeRegExp(city),
+        $options: 'i',
+      };
+    }
+    if (category) filter.eventType = category;
 
     const [data, total] = await Promise.all([
       this.eventModel.find(filter).skip(skip).limit(limit).lean().select('-__v'),
@@ -72,6 +79,33 @@ export class EventsService {
     ]);
 
     return { data, total, page, limit };
+  }
+
+  async getPublicCategoryCounts(): Promise<{
+    data: Array<{ category: string; count: number }>;
+    total: number;
+  }> {
+    const filter = {
+      status: EventStatus.PUBLISHED,
+      visibility: EventVisibility.PUBLIC,
+      eventType: { $exists: true, $ne: null },
+    };
+    const [groups, total] = await Promise.all([
+      this.eventModel.aggregate<{ _id: string; count: number }>([
+        { $match: filter },
+        { $group: { _id: '$eventType', count: { $sum: 1 } } },
+        { $sort: { count: -1, _id: 1 } },
+      ]),
+      this.eventModel.countDocuments({
+        status: EventStatus.PUBLISHED,
+        visibility: EventVisibility.PUBLIC,
+      }),
+    ]);
+
+    return {
+      data: groups.map(({ _id, count }) => ({ category: _id, count })),
+      total,
+    };
   }
 
   async findOne(id: string, organizerId: string): Promise<Event> {

--- a/src/modules/media/media-environment.spec.ts
+++ b/src/modules/media/media-environment.spec.ts
@@ -1,0 +1,17 @@
+import { getMediaRootPrefix } from './media-environment';
+
+describe('media environment', () => {
+  it('construit le préfixe Cloudinary exact et sensible à la casse', () => {
+    expect(getMediaRootPrefix('dev')).toBe('Elintys/dev');
+    expect(getMediaRootPrefix('prod')).toBe('Elintys/prod');
+  });
+
+  it.each([undefined, '', 'staging', 'production'])(
+    'refuse un environnement ambigu (%s)',
+    (environment) => {
+      expect(() => getMediaRootPrefix(environment as never)).toThrow(
+        'MEDIA_ENVIRONMENT_INVALID',
+      );
+    },
+  );
+});

--- a/src/modules/media/media-environment.ts
+++ b/src/modules/media/media-environment.ts
@@ -1,0 +1,10 @@
+import type { ElintysEnvironment } from '../../config/elintys-environment';
+
+export function getMediaRootPrefix(
+  environment: ElintysEnvironment | undefined,
+): string {
+  if (environment !== 'dev' && environment !== 'prod') {
+    throw new Error('MEDIA_ENVIRONMENT_INVALID');
+  }
+  return `Elintys/${environment}`;
+}

--- a/src/modules/vendors/dto/query-vendor.dto.ts
+++ b/src/modules/vendors/dto/query-vendor.dto.ts
@@ -1,7 +1,14 @@
-import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
-import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { VendorCategory } from '../vendor.schema';
+
+export enum VendorPriceTier {
+  BUDGET = '$',
+  STANDARD = '$$',
+  PREMIUM = '$$$',
+  LUXURY = '$$$$',
+}
 
 export class QueryVendorDto {
   @ApiPropertyOptional({ default: 1, minimum: 1, description: 'Numéro de page' })
@@ -23,4 +30,19 @@ export class QueryVendorDto {
   @IsOptional()
   @IsEnum(VendorCategory)
   category?: VendorCategory;
+
+  @ApiPropertyOptional({ example: 'Montréal', description: 'Filtrer par zone de service' })
+  @IsOptional()
+  @Transform(({ value }: { value: string }) => value?.trim())
+  @IsString()
+  @MaxLength(100)
+  city?: string;
+
+  @ApiPropertyOptional({
+    enum: VendorPriceTier,
+    description: 'Filtrer par prix de départ ($ ≤ 1000, $$ ≤ 2500, $$$ ≤ 5000, $$$$ > 5000 CAD)',
+  })
+  @IsOptional()
+  @IsEnum(VendorPriceTier)
+  price?: VendorPriceTier;
 }

--- a/src/modules/vendors/vendor.schema.ts
+++ b/src/modules/vendors/vendor.schema.ts
@@ -69,6 +69,8 @@ export class VendorProfile {
 
 export const VendorProfileSchema = SchemaFactory.createForClass(VendorProfile);
 VendorProfileSchema.index({ category: 1, isActive: 1 });
+VendorProfileSchema.index({ serviceArea: 1, isActive: 1 });
+VendorProfileSchema.index({ 'priceRange.min': 1, isActive: 1 });
 VendorProfileSchema.index({ rating: -1 });
 
 export type VendorRequestDocument = HydratedDocument<VendorRequest>;

--- a/src/modules/vendors/vendors.controller.ts
+++ b/src/modules/vendors/vendors.controller.ts
@@ -33,6 +33,8 @@ export class VendorsController {
   @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
   @ApiQuery({ name: 'limit', required: false, type: Number, example: 20 })
   @ApiQuery({ name: 'category', required: false, enum: ['photographe', 'traiteur', 'decorateur', 'animateur', 'dj', 'sonorisation', 'autre'] })
+  @ApiQuery({ name: 'city', required: false, type: String, example: 'Montréal' })
+  @ApiQuery({ name: 'price', required: false, enum: ['$', '$$', '$$$', '$$$$'] })
   @ApiResponse({ status: 200, description: 'Liste paginée de prestataires' })
   findAll(@Query() query: QueryVendorDto) {
     return this.vendorsService.findAll(query);

--- a/src/modules/vendors/vendors.service.spec.ts
+++ b/src/modules/vendors/vendors.service.spec.ts
@@ -9,6 +9,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { EmailsService } from '../emails/emails.service';
 import { User } from '../auth/user.schema';
 import { Event } from '../events/event.schema';
+import { VendorPriceTier } from './dto/query-vendor.dto';
 
 const makeChainable = (value: unknown) => {
   const chain: Record<string, unknown> = {};
@@ -153,6 +154,20 @@ describe('VendorsService', () => {
 
       expect(vendorModel.find).toHaveBeenCalledWith(
         expect.objectContaining({ category: VendorCategory.TRAITEUR }),
+      );
+    });
+
+    it('filtre par ville et gamme de prix si fournies', async () => {
+      await service.findAll({
+        city: 'Montréal',
+        price: VendorPriceTier.STANDARD,
+      });
+
+      expect(vendorModel.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceArea: { $regex: 'Montréal', $options: 'i' },
+          'priceRange.min': { $gt: 1000, $lte: 2500 },
+        }),
       );
     });
   });

--- a/src/modules/vendors/vendors.service.ts
+++ b/src/modules/vendors/vendors.service.ts
@@ -5,7 +5,7 @@ import { Model, Types } from 'mongoose';
 import { VendorProfile, VendorProfileDocument, VendorRequest, VendorRequestDocument, VendorRequestSource, VendorRequestStatus } from './vendor.schema';
 import { CreateVendorDto } from './dto/create-vendor.dto';
 import { UpdateVendorDto } from './dto/update-vendor.dto';
-import { QueryVendorDto } from './dto/query-vendor.dto';
+import { QueryVendorDto, VendorPriceTier } from './dto/query-vendor.dto';
 import { CreateVendorRequestDto } from './dto/create-request.dto';
 import { RespondVendorRequestDto } from './dto/respond-request.dto';
 import { PaginatedResult } from '../../shared/interfaces/paginated-result.interface';
@@ -15,6 +15,7 @@ import { NotificationType } from '../notifications/notification.schema';
 import { EmailsService } from '../emails/emails.service';
 import { User, UserDocument } from '../auth/user.schema';
 import { Event, EventDocument } from '../events/event.schema';
+import { escapeRegExp } from '../../shared/utils/escape-regexp';
 
 @Injectable()
 export class VendorsService {
@@ -37,11 +38,18 @@ export class VendorsService {
   }
 
   async findAll(query: QueryVendorDto): Promise<PaginatedResult<VendorProfile>> {
-    const { page = 1, limit = 20, category } = query;
+    const { page = 1, limit = 20, category, city, price } = query;
     const skip = (page - 1) * limit;
 
     const filter: Record<string, unknown> = { isActive: true };
     if (category) filter['category'] = category;
+    if (city) {
+      filter.serviceArea = {
+        $regex: escapeRegExp(city),
+        $options: 'i',
+      };
+    }
+    if (price) filter['priceRange.min'] = this.getPriceTierFilter(price);
 
     const [data, total] = await Promise.all([
       this.vendorModel.find(filter).skip(skip).limit(limit).sort({ rating: -1 }).lean().select('-__v'),
@@ -49,6 +57,19 @@ export class VendorsService {
     ]);
 
     return { data, total, page, limit };
+  }
+
+  private getPriceTierFilter(price: VendorPriceTier): Record<string, number> {
+    switch (price) {
+      case VendorPriceTier.BUDGET:
+        return { $gte: 0, $lte: 1000 };
+      case VendorPriceTier.STANDARD:
+        return { $gt: 1000, $lte: 2500 };
+      case VendorPriceTier.PREMIUM:
+        return { $gt: 2500, $lte: 5000 };
+      case VendorPriceTier.LUXURY:
+        return { $gt: 5000 };
+    }
   }
 
   async findOne(id: string): Promise<VendorProfile> {

--- a/src/modules/venues/dto/create-venue.dto.ts
+++ b/src/modules/venues/dto/create-venue.dto.ts
@@ -1,5 +1,6 @@
 import {
   IsEmail,
+  IsEnum,
   IsInt,
   IsOptional,
   IsString,
@@ -9,6 +10,7 @@ import {
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { VenueType } from '../venue.schema';
 
 export class AddressDto {
   @ApiProperty({ example: '1234 Rue Sainte-Catherine Ouest', maxLength: 300 })
@@ -44,6 +46,11 @@ export class CreateVenueDto {
   @IsString()
   @MaxLength(200)
   name!: string;
+
+  @ApiPropertyOptional({ enum: VenueType, default: VenueType.OTHER })
+  @IsOptional()
+  @IsEnum(VenueType)
+  type?: VenueType;
 
   @ApiPropertyOptional({ example: 'Salle de réception historique au cœur du centre-ville.', maxLength: 3000 })
   @IsOptional()

--- a/src/modules/venues/dto/query-venue.dto.ts
+++ b/src/modules/venues/dto/query-venue.dto.ts
@@ -1,0 +1,52 @@
+import { Transform, Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { VenueType } from '../venue.schema';
+
+export class QueryVenueDto {
+  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ enum: VenueType })
+  @IsOptional()
+  @IsEnum(VenueType)
+  type?: VenueType;
+
+  @ApiPropertyOptional({ example: 'Montréal' })
+  @IsOptional()
+  @Transform(({ value }: { value: string }) => value?.trim())
+  @IsString()
+  @MaxLength(100)
+  city?: string;
+
+  @ApiPropertyOptional({
+    example: 200,
+    minimum: 1,
+    description: 'Capacité minimale requise',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  capacity?: number;
+}

--- a/src/modules/venues/venue.schema.ts
+++ b/src/modules/venues/venue.schema.ts
@@ -3,6 +3,16 @@ import { HydratedDocument, Types } from 'mongoose';
 
 export type VenueProfileDocument = HydratedDocument<VenueProfile>;
 
+export enum VenueType {
+  CONFERENCE = 'conference',
+  RECEPTION = 'reception',
+  STUDIO = 'studio',
+  RESTAURANT = 'restaurant',
+  ROOFTOP = 'rooftop',
+  SPECTACLE = 'spectacle',
+  OTHER = 'other',
+}
+
 @Schema({ _id: false })
 class VenueAddress {
   @Prop({ required: true, trim: true })
@@ -25,6 +35,9 @@ export class VenueProfile {
 
   @Prop({ required: true, trim: true, maxlength: 200 })
   name!: string;
+
+  @Prop({ enum: Object.values(VenueType), default: VenueType.OTHER })
+  type!: VenueType;
 
   @Prop({ maxlength: 3000 })
   description?: string;
@@ -62,6 +75,7 @@ export class VenueProfile {
 
 export const VenueProfileSchema = SchemaFactory.createForClass(VenueProfile);
 VenueProfileSchema.index({ 'address.city': 1, isActive: 1 });
+VenueProfileSchema.index({ type: 1, isActive: 1 });
 VenueProfileSchema.index({ capacity: 1 });
 
 export type VenueBookingDocument = HydratedDocument<VenueBooking>;

--- a/src/modules/venues/venues.controller.spec.ts
+++ b/src/modules/venues/venues.controller.spec.ts
@@ -39,20 +39,22 @@ describe('VenuesController', () => {
 
   // ── GET /venues ──
   describe('findAll', () => {
-    it('délègue à venuesService.findAll avec page et limit par défaut', async () => {
+    it('délègue à venuesService.findAll avec le DTO de requête', async () => {
       mockVenuesService.findAll.mockResolvedValue({ data: [], total: 0 });
+      const query = {};
 
-      await controller.findAll(undefined, undefined);
+      await controller.findAll(query);
 
-      expect(mockVenuesService.findAll).toHaveBeenCalledWith(1, 20);
+      expect(mockVenuesService.findAll).toHaveBeenCalledWith(query);
     });
 
-    it('passe les valeurs de page et limit parsées', async () => {
+    it('transmet les filtres validés', async () => {
       mockVenuesService.findAll.mockResolvedValue({ data: [], total: 0 });
+      const query = { page: 2, limit: 5, city: 'Montréal', capacity: 200 };
 
-      await controller.findAll('2', '5');
+      await controller.findAll(query);
 
-      expect(mockVenuesService.findAll).toHaveBeenCalledWith(2, 5);
+      expect(mockVenuesService.findAll).toHaveBeenCalledWith(query);
     });
   });
 

--- a/src/modules/venues/venues.controller.ts
+++ b/src/modules/venues/venues.controller.ts
@@ -12,6 +12,7 @@ import { CreateVenueDto } from './dto/create-venue.dto';
 import { UpdateVenueDto } from './dto/update-venue.dto';
 import { CreateVenueBookingDto } from './dto/create-booking.dto';
 import { RespondVenueBookingDto } from './dto/respond-booking.dto';
+import { QueryVenueDto } from './dto/query-venue.dto';
 import { CurrentUser, JwtPayload } from '../../shared/decorators/current-user.decorator';
 import { Public } from '../../shared/decorators/public.decorator';
 import { Roles, Role } from '../../shared/decorators/roles.decorator';
@@ -36,9 +37,12 @@ export class VenuesController {
   @ApiOperation({ summary: 'Lister les salles' })
   @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
   @ApiQuery({ name: 'limit', required: false, type: Number, example: 20 })
+  @ApiQuery({ name: 'type', required: false, enum: ['conference', 'reception', 'studio', 'restaurant', 'rooftop', 'spectacle', 'other'] })
+  @ApiQuery({ name: 'city', required: false, type: String, example: 'Montréal' })
+  @ApiQuery({ name: 'capacity', required: false, type: Number, description: 'Capacité minimale' })
   @ApiResponse({ status: 200, description: 'Liste paginée de salles' })
-  findAll(@Query('page') page?: string, @Query('limit') limit?: string) {
-    return this.venuesService.findAll(page ? parseInt(page, 10) : 1, limit ? parseInt(limit, 10) : 20);
+  findAll(@Query() query: QueryVenueDto) {
+    return this.venuesService.findAll(query);
   }
 
   @Get('me')

--- a/src/modules/venues/venues.service.spec.ts
+++ b/src/modules/venues/venues.service.spec.ts
@@ -9,7 +9,7 @@ import { getModelToken } from '@nestjs/mongoose';
 import { ConfigService } from '@nestjs/config';
 import { Types } from 'mongoose';
 import { VenuesService } from './venues.service';
-import { VenueBooking, VenueBookingSchema, VenueBookingStatus, VenueProfile } from './venue.schema';
+import { VenueBooking, VenueBookingSchema, VenueBookingStatus, VenueProfile, VenueType } from './venue.schema';
 import { NotificationsService } from '../notifications/notifications.service';
 import { EmailsService } from '../emails/emails.service';
 import { User } from '../auth/user.schema';
@@ -129,11 +129,26 @@ describe('VenuesService', () => {
   // ── findAll ──
   describe('findAll', () => {
     it('retourne une liste paginée de salles actives', async () => {
-      const result = await service.findAll(1, 20);
+      const result = await service.findAll({ page: 1, limit: 20 });
 
       expect(result.data).toHaveLength(1);
       expect(result.total).toBe(1);
       expect(venueModel.find).toHaveBeenCalledWith({ isActive: true });
+    });
+
+    it('filtre par type, ville et capacité minimale', async () => {
+      await service.findAll({
+        type: VenueType.ROOFTOP,
+        city: 'Montréal',
+        capacity: 200,
+      });
+
+      expect(venueModel.find).toHaveBeenCalledWith({
+        isActive: true,
+        type: VenueType.ROOFTOP,
+        'address.city': { $regex: 'Montréal', $options: 'i' },
+        capacity: { $gte: 200 },
+      });
     });
   });
 

--- a/src/modules/venues/venues.service.ts
+++ b/src/modules/venues/venues.service.ts
@@ -19,6 +19,7 @@ import { CreateVenueDto } from './dto/create-venue.dto';
 import { UpdateVenueDto } from './dto/update-venue.dto';
 import { CreateVenueBookingDto } from './dto/create-booking.dto';
 import { RespondVenueBookingDto } from './dto/respond-booking.dto';
+import { QueryVenueDto } from './dto/query-venue.dto';
 import { PaginatedResult } from '../../shared/interfaces/paginated-result.interface';
 import { ErrorCodes } from '../../shared/constants/error-codes';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -26,6 +27,7 @@ import { NotificationType } from '../notifications/notification.schema';
 import { EmailsService } from '../emails/emails.service';
 import { User, UserDocument } from '../auth/user.schema';
 import { Event, EventDocument } from '../events/event.schema';
+import { escapeRegExp } from '../../shared/utils/escape-regexp';
 
 @Injectable()
 export class VenuesService {
@@ -47,11 +49,21 @@ export class VenuesService {
     return venue.toObject();
   }
 
-  async findAll(page = 1, limit = 20): Promise<PaginatedResult<VenueProfile>> {
+  async findAll(query: QueryVenueDto): Promise<PaginatedResult<VenueProfile>> {
+    const { page = 1, limit = 20, type, city, capacity } = query;
     const skip = (page - 1) * limit;
+    const filter: Record<string, unknown> = { isActive: true };
+    if (type) filter.type = type;
+    if (city) {
+      filter['address.city'] = {
+        $regex: escapeRegExp(city),
+        $options: 'i',
+      };
+    }
+    if (capacity) filter.capacity = { $gte: capacity };
     const [data, total] = await Promise.all([
-      this.venueModel.find({ isActive: true }).skip(skip).limit(limit).sort({ rating: -1 }).lean().select('-__v'),
-      this.venueModel.countDocuments({ isActive: true }),
+      this.venueModel.find(filter).skip(skip).limit(limit).sort({ rating: -1 }).lean().select('-__v'),
+      this.venueModel.countDocuments(filter),
     ]);
     return { data, total, page, limit };
   }

--- a/src/scripts/migrate-event-media.ts
+++ b/src/scripts/migrate-event-media.ts
@@ -8,6 +8,8 @@ import {
   UploadedImageFile,
 } from '../modules/media/image-file-validation.service';
 import { MEDIA_MAX_FILE_SIZE } from '../modules/media/media.constants';
+import { resolveElintysEnvironment } from '../config/elintys-environment';
+import { getMediaRootPrefix } from '../modules/media/media-environment';
 
 const ALLOWED_LEGACY_HOSTS = new Set([
   'images.unsplash.com',
@@ -71,6 +73,12 @@ async function downloadLegacyImage(urlValue: string): Promise<UploadedImageFile>
 async function main(): Promise<void> {
   const uri = process.env.MONGODB_URI;
   if (!uri) throw new Error('MONGODB_URI is required');
+  const mediaRootPrefix = getMediaRootPrefix(
+    resolveElintysEnvironment(
+      process.env.ELINTYS_ENV,
+      process.env.NODE_ENV ?? 'development',
+    ),
+  );
   await mongoose.connect(uri);
 
   const collection = mongoose.connection.db?.collection<LegacyEvent>('events');
@@ -108,7 +116,7 @@ async function main(): Promise<void> {
     const normalized = await validator.validateAndNormalize(file);
     const uploaded = await storage.uploadImage({
       buffer: normalized.buffer,
-      publicId: `elintys/events/${event._id.toString()}/cover/${randomUUID()}`,
+      publicId: `${mediaRootPrefix}/events/${event._id.toString()}/cover/${randomUUID()}`,
     });
     const result = await collection.updateOne(
       { _id: event._id, coverImage: event.coverImage } as never,

--- a/src/scripts/seed-development.spec.ts
+++ b/src/scripts/seed-development.spec.ts
@@ -1,0 +1,28 @@
+import { assertDevelopmentSeedAllowed } from './seed-development';
+
+describe('development seed guard', () => {
+  const devUri =
+    'mongodb+srv://user:password@example.mongodb.net/elintys-dev?retryWrites=true';
+
+  it('autorise uniquement development avec la base elintys-dev', () => {
+    expect(() =>
+      assertDevelopmentSeedAllowed('dev', devUri),
+    ).not.toThrow();
+  });
+
+  it('refuse ELINTYS_ENV=prod', () => {
+    expect(() => assertDevelopmentSeedAllowed('prod', devUri)).toThrow(
+      'SEED_REFUSED',
+    );
+  });
+
+  it.each([
+    'mongodb+srv://user:password@example.mongodb.net/elintys',
+    'mongodb+srv://user:password@example.mongodb.net/elintys-prod',
+    'mongodb://localhost:27017/elintys',
+  ])('refuse la base non-dev %s', (uri) => {
+    expect(() =>
+      assertDevelopmentSeedAllowed('dev', uri),
+    ).toThrow('database must be exactly "elintys-dev"');
+  });
+});

--- a/src/scripts/seed-development.ts
+++ b/src/scripts/seed-development.ts
@@ -1,0 +1,749 @@
+import 'dotenv/config';
+import * as bcrypt from 'bcrypt';
+import mongoose, { Model, Types } from 'mongoose';
+import {
+  User,
+  UserRole,
+  UserSchema,
+} from '../modules/auth/user.schema';
+import {
+  Event,
+  EventLocationType,
+  EventSchema,
+  EventStatus,
+  EventType,
+  EventVisibility,
+  VenueMode,
+} from '../modules/events/event.schema';
+import {
+  VendorCategory,
+  VendorProfile,
+  VendorProfileSchema,
+} from '../modules/vendors/vendor.schema';
+import {
+  VenueProfile,
+  VenueProfileSchema,
+  VenueType,
+} from '../modules/venues/venue.schema';
+import {
+  ElintysEnvironment,
+  resolveElintysEnvironment,
+} from '../config/elintys-environment';
+
+const DEV_DATABASE_NAME = 'elintys-dev';
+const DEMO_PASSWORD = 'Elintys-Dev-2026!';
+
+export function assertDevelopmentSeedAllowed(
+  elintysEnvironment: ElintysEnvironment,
+  mongoUri: string | undefined,
+): asserts mongoUri is string {
+  if (elintysEnvironment !== 'dev') {
+    throw new Error('SEED_REFUSED: ELINTYS_ENV must be exactly "dev".');
+  }
+  if (!mongoUri) {
+    throw new Error('SEED_REFUSED: MONGODB_URI is required.');
+  }
+
+  let databaseName: string;
+  try {
+    databaseName = decodeURIComponent(new URL(mongoUri).pathname.slice(1));
+  } catch {
+    throw new Error('SEED_REFUSED: MONGODB_URI is invalid.');
+  }
+  if (databaseName !== DEV_DATABASE_NAME) {
+    throw new Error(
+      `SEED_REFUSED: database must be exactly "${DEV_DATABASE_NAME}".`,
+    );
+  }
+}
+
+interface DemoUserInput {
+  key: string;
+  fullName: string;
+  email: string;
+  roles: UserRole[];
+}
+
+const DEMO_USERS: DemoUserInput[] = [
+  {
+    key: 'organizer',
+    fullName: 'Olivia Organisatrice',
+    email: 'organisateur@demo.elintys.com',
+    roles: [UserRole.ORGANISATEUR],
+  },
+  {
+    key: 'vendor-photographer',
+    fullName: 'Philippe Photographe',
+    email: 'prestataire@demo.elintys.com',
+    roles: [UserRole.PRESTATAIRE],
+  },
+  {
+    key: 'venue-manager',
+    fullName: 'Gabrielle Gestionnaire',
+    email: 'gestionnaire@demo.elintys.com',
+    roles: [UserRole.GESTIONNAIRE_SALLE],
+  },
+  {
+    key: 'participant',
+    fullName: 'Patrice Participant',
+    email: 'participant@demo.elintys.com',
+    roles: [UserRole.PARTICIPANT],
+  },
+  ...[
+    ['vendor-catering', 'Théo Traiteur', 'traiteur'],
+    ['vendor-dj', 'Diane DJ', 'dj'],
+    ['vendor-decorator', 'Déborah Décoratrice', 'decorateur'],
+    ['vendor-host', 'Alex Animateur', 'animateur'],
+    ['vendor-sound', 'Sonia Sonorisation', 'sonorisation'],
+    ['vendor-video', 'Victor Vidéaste', 'video'],
+    ['vendor-floral', 'Flora Fleuriste', 'fleuriste'],
+    ['vendor-pastry', 'Camille Pâtissière', 'patisserie'],
+    ['vendor-lighting', 'Luc Éclairagiste', 'eclairage'],
+    ['venue-rooftop', 'Roxane Rooftop', 'rooftop'],
+    ['venue-studio', 'Stéphane Studio', 'studio'],
+    ['venue-conference', 'Constance Conférence', 'conference'],
+    ['venue-restaurant', 'Rémi Restaurant', 'restaurant'],
+    ['venue-spectacle', 'Salomé Spectacle', 'spectacle'],
+    ['venue-loft', 'Léa Loft', 'loft'],
+    ['venue-garden', 'Jade Jardin', 'jardin'],
+    ['venue-gallery', 'Gaëlle Galerie', 'galerie'],
+    ['venue-hotel', 'Hugo Hôtel', 'hotel'],
+  ].map(([key, fullName, slug]) => ({
+    key,
+    fullName,
+    email: `${slug}@demo.elintys.com`,
+    roles: [
+      key.startsWith('venue-')
+        ? UserRole.GESTIONNAIRE_SALLE
+        : UserRole.PRESTATAIRE,
+    ],
+  })),
+];
+
+async function upsertUsers(
+  userModel: Model<User>,
+): Promise<Map<string, Types.ObjectId>> {
+  const passwordHash = await bcrypt.hash(DEMO_PASSWORD, 12);
+  const ids = new Map<string, Types.ObjectId>();
+
+  for (const input of DEMO_USERS) {
+    const user = await userModel.findOneAndUpdate(
+      { email: input.email },
+      {
+        $set: {
+          fullName: input.fullName,
+          roles: input.roles,
+          password: passwordHash,
+          isEmailVerified: true,
+          onboardingCompleted: true,
+          onboardingByRole: Object.fromEntries(
+            input.roles.map((role) => [role, true]),
+          ),
+        },
+        $setOnInsert: {
+          referralBalance: 0,
+          subscriptions: [],
+          onboardingData: {},
+        },
+        $unset: {
+          emailVerificationToken: 1,
+          emailVerificationExpiresAt: 1,
+          passwordResetToken: 1,
+          passwordResetExpires: 1,
+          refreshToken: 1,
+        },
+      },
+      { upsert: true, new: true, runValidators: true },
+    );
+    ids.set(input.key, user._id);
+  }
+
+  return ids;
+}
+
+function requireId(ids: Map<string, Types.ObjectId>, key: string): Types.ObjectId {
+  const id = ids.get(key);
+  if (!id) throw new Error(`SEED_INVARIANT_FAILED: missing user "${key}".`);
+  return id;
+}
+
+async function upsertVendors(
+  vendorModel: Model<VendorProfile>,
+  userIds: Map<string, Types.ObjectId>,
+): Promise<Types.ObjectId[]> {
+  const inputs = [
+    {
+      userKey: 'vendor-photographer',
+      businessName: 'Lumière Nord',
+      category: VendorCategory.PHOTOGRAPHE,
+      description: 'Photographie éditoriale et événementielle à Montréal.',
+      priceRange: { min: 850, max: 3200, currency: 'CAD' },
+      serviceArea: 'Grand Montréal, Laval et Longueuil',
+      rating: 4.9,
+      reviewCount: 47,
+    },
+    {
+      userKey: 'vendor-catering',
+      businessName: 'Maison Papille',
+      category: VendorCategory.TRAITEUR,
+      description: 'Menus locaux et service traiteur pour réceptions.',
+      priceRange: { min: 1800, max: 9000, currency: 'CAD' },
+      serviceArea: 'Montréal et Rive-Sud',
+      rating: 4.8,
+      reviewCount: 31,
+    },
+    {
+      userKey: 'vendor-dj',
+      businessName: 'Onde Nocturne',
+      category: VendorCategory.DJ,
+      description: 'DJ, sonorisation et ambiance musicale sur mesure.',
+      priceRange: { min: 2800, max: 6500, currency: 'CAD' },
+      serviceArea: 'Grand Montréal et Québec',
+      rating: 4.7,
+      reviewCount: 62,
+    },
+    {
+      userKey: 'vendor-decorator',
+      businessName: 'Atelier Éclat',
+      category: VendorCategory.DECORATEUR,
+      description: 'Direction artistique florale et scénographie.',
+      priceRange: { min: 6200, max: 18000, currency: 'CAD' },
+      serviceArea: 'Montréal, Laval et Longueuil',
+      rating: 4.9,
+      reviewCount: 24,
+    },
+    {
+      userKey: 'vendor-host',
+      businessName: 'Micro Ouvert',
+      category: VendorCategory.ANIMATEUR,
+      description: 'Animation bilingue de galas et événements corporatifs.',
+      priceRange: { min: 1200, max: 3500, currency: 'CAD' },
+      serviceArea: 'Québec et Grand Montréal',
+      rating: 4.6,
+      reviewCount: 18,
+    },
+    {
+      userKey: 'vendor-sound',
+      businessName: 'Résonance Pro',
+      category: VendorCategory.SONORISATION,
+      description: 'Sonorisation, micros et régie technique événementielle.',
+      priceRange: { min: 2400, max: 11000, currency: 'CAD' },
+      serviceArea: 'Montréal, Laval et Longueuil',
+      rating: 4.8,
+      reviewCount: 29,
+    },
+    {
+      userKey: 'vendor-video',
+      businessName: 'Mouvement Studio',
+      category: VendorCategory.AUTRE,
+      description: 'Captation vidéo et diffusion en direct.',
+      priceRange: { min: 3500, max: 14000, currency: 'CAD' },
+      serviceArea: 'Grand Montréal et Québec',
+      rating: 4.7,
+      reviewCount: 22,
+    },
+    {
+      userKey: 'vendor-floral',
+      businessName: 'Flore Locale',
+      category: VendorCategory.DECORATEUR,
+      description: 'Design floral durable pour événements privés et corporatifs.',
+      priceRange: { min: 950, max: 7500, currency: 'CAD' },
+      serviceArea: 'Montréal et Rive-Sud',
+      rating: 4.9,
+      reviewCount: 41,
+    },
+    {
+      userKey: 'vendor-pastry',
+      businessName: 'Sucre Atelier',
+      category: VendorCategory.TRAITEUR,
+      description: 'Pâtisserie sur mesure et tables gourmandes.',
+      priceRange: { min: 650, max: 4200, currency: 'CAD' },
+      serviceArea: 'Montréal, Laval et Longueuil',
+      rating: 4.6,
+      reviewCount: 33,
+    },
+    {
+      userKey: 'vendor-lighting',
+      businessName: 'Lueur Scénique',
+      category: VendorCategory.SONORISATION,
+      description: 'Éclairage architectural et scénographique.',
+      priceRange: { min: 5400, max: 20000, currency: 'CAD' },
+      serviceArea: 'Québec et Grand Montréal',
+      rating: 4.8,
+      reviewCount: 17,
+    },
+  ];
+
+  const ids: Types.ObjectId[] = [];
+  for (const input of inputs) {
+    const { userKey, ...profile } = input;
+    const user = requireId(userIds, userKey);
+    const vendor = await vendorModel.findOneAndUpdate(
+      { user },
+      {
+        $set: {
+          ...profile,
+          user,
+          photos: [],
+          isActive: true,
+          isPremium: profile.rating >= 4.9,
+          contactEmail: DEMO_USERS.find((item) => item.key === userKey)?.email,
+        },
+      },
+      { upsert: true, new: true, runValidators: true },
+    );
+    ids.push(vendor._id);
+  }
+  return ids;
+}
+
+async function upsertVenues(
+  venueModel: Model<VenueProfile>,
+  userIds: Map<string, Types.ObjectId>,
+): Promise<Types.ObjectId[]> {
+  const inputs = [
+    {
+      userKey: 'venue-manager',
+      name: 'Maison Saint-Laurent',
+      type: VenueType.RECEPTION,
+      description: 'Espace lumineux au cœur du Vieux-Montréal.',
+      address: {
+        street: '125 rue Saint-Paul Ouest',
+        city: 'Montréal',
+        province: 'QC',
+        postalCode: 'H2Y 1Z5',
+      },
+      capacity: 280,
+      amenities: ['Cuisine', 'Vestiaire', 'Accessibilité', 'Wi-Fi'],
+      pricePerDay: 4800,
+      rating: 4.9,
+      reviewCount: 36,
+    },
+    {
+      userKey: 'venue-rooftop',
+      name: 'Terrasse Boréale',
+      type: VenueType.ROOFTOP,
+      description: 'Rooftop avec vue panoramique sur Montréal.',
+      address: {
+        street: '800 boulevard René-Lévesque',
+        city: 'Montréal',
+        province: 'QC',
+        postalCode: 'H3B 1X9',
+      },
+      capacity: 140,
+      amenities: ['Bar', 'Sonorisation', 'Vue panoramique'],
+      pricePerDay: 3900,
+      rating: 4.7,
+      reviewCount: 21,
+    },
+    {
+      userKey: 'venue-studio',
+      name: 'Studio du Canal',
+      type: VenueType.STUDIO,
+      description: 'Studio modulable pour lancements et ateliers.',
+      address: {
+        street: '2100 rue du Centre',
+        city: 'Montréal',
+        province: 'QC',
+        postalCode: 'H3K 1J4',
+      },
+      capacity: 80,
+      amenities: ['Éclairage', 'Projecteur', 'Wi-Fi'],
+      pricePerDay: 1800,
+      rating: 4.6,
+      reviewCount: 14,
+    },
+    {
+      userKey: 'venue-conference',
+      name: 'Forum du Mile End',
+      type: VenueType.CONFERENCE,
+      description: 'Salle équipée pour conférences et formations.',
+      address: {
+        street: '5555 avenue de Gaspé',
+        city: 'Montréal',
+        province: 'QC',
+        postalCode: 'H2T 2A3',
+      },
+      capacity: 320,
+      amenities: ['Projecteur', 'Scène', 'Wi-Fi', 'Accessibilité'],
+      pricePerDay: 5200,
+      rating: 4.8,
+      reviewCount: 28,
+    },
+    {
+      userKey: 'venue-restaurant',
+      name: 'Table du Vieux-Port',
+      type: VenueType.RESTAURANT,
+      description: 'Restaurant privatisable avec cuisine ouverte.',
+      address: {
+        street: '88 rue de la Commune',
+        city: 'Montréal',
+        province: 'QC',
+        postalCode: 'H2Y 2C6',
+      },
+      capacity: 110,
+      amenities: ['Cuisine', 'Bar', 'Terrasse'],
+      pricePerDay: 3600,
+      rating: 4.7,
+      reviewCount: 44,
+    },
+    {
+      userKey: 'venue-spectacle',
+      name: 'Théâtre du Parc',
+      type: VenueType.SPECTACLE,
+      description: 'Salle de spectacle avec scène et régie complète.',
+      address: {
+        street: '4600 avenue du Parc',
+        city: 'Montréal',
+        province: 'QC',
+        postalCode: 'H2V 4E5',
+      },
+      capacity: 620,
+      amenities: ['Scène', 'Loges', 'Sonorisation', 'Éclairage'],
+      pricePerDay: 8200,
+      rating: 4.9,
+      reviewCount: 51,
+    },
+    {
+      userKey: 'venue-loft',
+      name: 'Loft Wellington',
+      type: VenueType.RECEPTION,
+      description: 'Loft industriel pour réceptions et lancements.',
+      address: {
+        street: '3900 rue Wellington',
+        city: 'Montréal',
+        province: 'QC',
+        postalCode: 'H4G 1V3',
+      },
+      capacity: 190,
+      amenities: ['Cuisine', 'Monte-charge', 'Wi-Fi'],
+      pricePerDay: 4100,
+      rating: 4.6,
+      reviewCount: 19,
+    },
+    {
+      userKey: 'venue-garden',
+      name: 'Jardin de Laval',
+      type: VenueType.RECEPTION,
+      description: 'Jardin et pavillon vitré pour célébrations.',
+      address: {
+        street: '1200 boulevard des Prairies',
+        city: 'Laval',
+        province: 'QC',
+        postalCode: 'H7N 2T5',
+      },
+      capacity: 240,
+      amenities: ['Jardin', 'Stationnement', 'Cuisine'],
+      pricePerDay: 5700,
+      rating: 4.8,
+      reviewCount: 26,
+    },
+    {
+      userKey: 'venue-gallery',
+      name: 'Galerie du Quartier',
+      type: VenueType.STUDIO,
+      description: 'Galerie contemporaine pour cocktails et expositions.',
+      address: {
+        street: '75 rue Saint-Joseph',
+        city: 'Québec',
+        province: 'QC',
+        postalCode: 'G1K 3A6',
+      },
+      capacity: 95,
+      amenities: ['Éclairage', 'Vestiaire', 'Wi-Fi'],
+      pricePerDay: 2300,
+      rating: 4.7,
+      reviewCount: 12,
+    },
+    {
+      userKey: 'venue-hotel',
+      name: 'Salon Laurentien',
+      type: VenueType.CONFERENCE,
+      description: 'Salon hôtelier modulable pour grands rassemblements.',
+      address: {
+        street: '1000 boulevard René-Lévesque',
+        city: 'Québec',
+        province: 'QC',
+        postalCode: 'G1R 5T8',
+      },
+      capacity: 1200,
+      amenities: ['Scène', 'Cuisine', 'Wi-Fi', 'Hébergement'],
+      pricePerDay: 15000,
+      rating: 4.9,
+      reviewCount: 63,
+    },
+  ];
+
+  const ids: Types.ObjectId[] = [];
+  for (const input of inputs) {
+    const { userKey, ...profile } = input;
+    const user = requireId(userIds, userKey);
+    const venue = await venueModel.findOneAndUpdate(
+      { user },
+      {
+        $set: {
+          ...profile,
+          user,
+          photos: [],
+          isActive: true,
+          contactEmail: DEMO_USERS.find((item) => item.key === userKey)?.email,
+        },
+      },
+      { upsert: true, new: true, runValidators: true },
+    );
+    ids.push(venue._id);
+  }
+  return ids;
+}
+
+async function upsertEvents(
+  eventModel: Model<Event>,
+  organizer: Types.ObjectId,
+  vendors: Types.ObjectId[],
+  venues: Types.ObjectId[],
+): Promise<void> {
+  const events = [
+    {
+      slug: 'sommet-innovation-montreal-demo',
+      title: 'Sommet Innovation Montréal',
+      eventType: EventType.CONFERENCE,
+      shortDescription: 'Une journée de rencontres autour des idées qui transforment le Québec.',
+      startDate: new Date('2027-04-22T13:00:00.000Z'),
+      endDate: new Date('2027-04-22T23:00:00.000Z'),
+      city: 'Montréal',
+      venueIndex: 0,
+      capacity: 250,
+    },
+    {
+      slug: 'gala-horizon-demo',
+      title: 'Gala Horizon',
+      eventType: EventType.GALA,
+      shortDescription: 'Un gala-bénéfice élégant réunissant la communauté créative.',
+      startDate: new Date('2027-05-15T22:00:00.000Z'),
+      endDate: new Date('2027-05-16T03:00:00.000Z'),
+      city: 'Montréal',
+      venueIndex: 0,
+      capacity: 220,
+    },
+    {
+      slug: 'atelier-marques-vivantes-demo',
+      title: 'Atelier Marques Vivantes',
+      eventType: EventType.WORKSHOP,
+      shortDescription: 'Un atelier pratique pour concevoir des expériences de marque mémorables.',
+      startDate: new Date('2027-06-05T14:00:00.000Z'),
+      endDate: new Date('2027-06-05T20:00:00.000Z'),
+      city: 'Montréal',
+      venueIndex: 2,
+      capacity: 70,
+    },
+    {
+      slug: 'nuits-du-canal-demo',
+      title: 'Nuits du Canal',
+      eventType: EventType.CONCERT,
+      shortDescription: 'Une soirée musicale intime portée par des artistes locaux.',
+      startDate: new Date('2027-07-10T23:00:00.000Z'),
+      endDate: new Date('2027-07-11T03:00:00.000Z'),
+      city: 'Montréal',
+      venueIndex: 2,
+      capacity: 75,
+    },
+    {
+      slug: 'reseautage-sur-les-toits-demo',
+      title: 'Réseautage sur les toits',
+      eventType: EventType.NETWORKING,
+      shortDescription: 'Des conversations utiles dans un décor panoramique.',
+      startDate: new Date('2027-08-19T21:00:00.000Z'),
+      endDate: new Date('2027-08-20T01:00:00.000Z'),
+      city: 'Montréal',
+      venueIndex: 1,
+      capacity: 120,
+    },
+    {
+      slug: 'mariage-jardin-demo',
+      title: 'Mariage au Jardin',
+      eventType: EventType.WEDDING,
+      shortDescription: 'Une célébration estivale dans un jardin lumineux.',
+      startDate: new Date('2027-09-04T19:00:00.000Z'),
+      endDate: new Date('2027-09-05T03:00:00.000Z'),
+      city: 'Laval',
+      venueIndex: 7,
+      capacity: 180,
+    },
+    {
+      slug: 'festival-creatif-demo',
+      title: 'Festival Créatif Québec',
+      eventType: EventType.FESTIVAL,
+      shortDescription: 'Deux jours de création, de musique et de rencontres.',
+      startDate: new Date('2027-09-18T14:00:00.000Z'),
+      endDate: new Date('2027-09-19T23:00:00.000Z'),
+      city: 'Québec',
+      venueIndex: 8,
+      capacity: 90,
+    },
+    {
+      slug: 'forum-leadership-demo',
+      title: 'Forum Leadership Responsable',
+      eventType: EventType.CORPORATE,
+      shortDescription: 'Des échanges concrets sur le leadership responsable.',
+      startDate: new Date('2027-10-07T13:00:00.000Z'),
+      endDate: new Date('2027-10-07T21:00:00.000Z'),
+      city: 'Montréal',
+      venueIndex: 3,
+      capacity: 300,
+    },
+    {
+      slug: 'anniversaire-studio-demo',
+      title: 'Anniversaire Studio 360',
+      eventType: EventType.BIRTHDAY,
+      shortDescription: 'Une expérience immersive pour une soirée mémorable.',
+      startDate: new Date('2027-10-23T22:00:00.000Z'),
+      endDate: new Date('2027-10-24T03:00:00.000Z'),
+      city: 'Montréal',
+      venueIndex: 2,
+      capacity: 70,
+    },
+    {
+      slug: 'expo-nouvelles-voix-demo',
+      title: 'Expo Nouvelles Voix',
+      eventType: EventType.OTHER,
+      shortDescription: 'Une exposition collective dédiée aux talents émergents.',
+      startDate: new Date('2027-11-12T17:00:00.000Z'),
+      endDate: new Date('2027-11-13T01:00:00.000Z'),
+      city: 'Québec',
+      venueIndex: 8,
+      capacity: 85,
+    },
+  ];
+
+  for (const input of events) {
+    const venue = venues[input.venueIndex];
+    await eventModel.findOneAndUpdate(
+      { slug: input.slug },
+      {
+        $set: {
+          title: input.title,
+          eventType: input.eventType,
+          shortDescription: input.shortDescription,
+          description: `${input.shortDescription} Données de démonstration réservées à l’environnement de développement Elintys.`,
+          startDate: input.startDate,
+          endDate: input.endDate,
+          location: {
+            type: EventLocationType.PHYSICAL,
+            name: input.title,
+            city: input.city,
+            province: 'Québec',
+          },
+          timezone: 'America/Toronto',
+          venueMode: VenueMode.EXISTING,
+          venueProfile: venue,
+          visibility: EventVisibility.PUBLIC,
+          status: EventStatus.PUBLISHED,
+          organizer,
+          vendors: vendors.slice(0, 3),
+          capacity: input.capacity,
+          gallery: [],
+          creationProgress: {
+            currentStep: 6,
+            completedSteps: [1, 2, 3, 4, 5, 6],
+            skippedSteps: [],
+            lastSavedAt: new Date(),
+          },
+        },
+      },
+      { upsert: true, new: true, runValidators: true },
+    );
+  }
+
+  await eventModel.findOneAndUpdate(
+    { slug: 'festival-rives-draft-demo' },
+    {
+      $set: {
+        title: 'Festival des Rives — brouillon',
+        eventType: EventType.FESTIVAL,
+        shortDescription: 'Brouillon de démonstration du parcours organisateur.',
+        location: {
+          type: EventLocationType.PHYSICAL,
+          city: 'Longueuil',
+          province: 'Québec',
+        },
+        timezone: 'America/Toronto',
+        visibility: EventVisibility.PUBLIC,
+        status: EventStatus.DRAFT,
+        organizer,
+        vendors: [],
+        gallery: [],
+        capacity: 500,
+        creationProgress: {
+          currentStep: 3,
+          completedSteps: [1, 2],
+          skippedSteps: [],
+          lastSavedAt: new Date(),
+        },
+      },
+    },
+    { upsert: true, new: true, runValidators: true },
+  );
+}
+
+export async function seedDevelopmentDatabase(): Promise<void> {
+  const mongoUri = process.env.MONGODB_URI;
+  const elintysEnvironment = resolveElintysEnvironment(
+    process.env.ELINTYS_ENV,
+    process.env.NODE_ENV ?? 'development',
+  );
+  assertDevelopmentSeedAllowed(elintysEnvironment, mongoUri);
+
+  await mongoose.connect(mongoUri);
+  try {
+    if (mongoose.connection.db?.databaseName !== DEV_DATABASE_NAME) {
+      throw new Error('SEED_REFUSED: connected database is not elintys-dev.');
+    }
+
+    const userModel = mongoose.connection.model<User>(
+      User.name,
+      UserSchema,
+    );
+    const vendorModel = mongoose.connection.model<VendorProfile>(
+      VendorProfile.name,
+      VendorProfileSchema,
+    );
+    const venueModel = mongoose.connection.model<VenueProfile>(
+      VenueProfile.name,
+      VenueProfileSchema,
+    );
+    const eventModel = mongoose.connection.model<Event>(
+      Event.name,
+      EventSchema,
+    );
+
+    const users = await upsertUsers(userModel);
+    const vendors = await upsertVendors(vendorModel, users);
+    const venues = await upsertVenues(venueModel, users);
+    await upsertEvents(
+      eventModel,
+      requireId(users, 'organizer'),
+      vendors,
+      venues,
+    );
+
+    await Promise.all([
+      userModel.createIndexes(),
+      vendorModel.createIndexes(),
+      venueModel.createIndexes(),
+      eventModel.createIndexes(),
+    ]);
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+if (require.main === module) {
+  seedDevelopmentDatabase()
+    .then(() => {
+      console.info('Seed dev Elintys terminé (idempotent, sans suppression).');
+    })
+    .catch((error: unknown) => {
+      console.error(error instanceof Error ? error.message : 'SEED_FAILED');
+      process.exitCode = 1;
+    });
+}

--- a/src/shared/filters/http-exception.filter.spec.ts
+++ b/src/shared/filters/http-exception.filter.spec.ts
@@ -1,0 +1,78 @@
+import {
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { AllExceptionsFilter } from './http-exception.filter';
+
+describe('AllExceptionsFilter', () => {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  const request = {
+    method: 'GET',
+    path: '/events',
+    requestId: 'req-123',
+    route: { path: '/events' },
+    url: '/events?private=value',
+  };
+  const host = {
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => ({ status }),
+    }),
+  } as unknown as ArgumentsHost;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('ajoute le requestId aux réponses en erreur', () => {
+    new AllExceptionsFilter().catch(
+      new HttpException('Introuvable', HttpStatus.NOT_FOUND),
+      host,
+    );
+
+    expect(status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: HttpStatus.NOT_FOUND,
+        message: 'Introuvable',
+        requestId: 'req-123',
+      }),
+    );
+  });
+
+  it("journalise les erreurs serveur sans message, query string ou données d'entrée", () => {
+    const errorSpy = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => undefined);
+    const exception = new Error(
+      'Database failed for person@example.com with token secret-jwt',
+    );
+
+    new AllExceptionsFilter().catch(exception, host);
+
+    const serializedLog = errorSpy.mock.calls[0][0] as string;
+    const logEntry = JSON.parse(serializedLog);
+    expect(logEntry).toEqual({
+      event: 'http_exception',
+      service: 'elintys-api',
+      requestId: 'req-123',
+      method: 'GET',
+      route: '/events',
+      status: HttpStatus.INTERNAL_SERVER_ERROR,
+      errorType: 'Error',
+    });
+    expect(serializedLog).not.toContain('person@example.com');
+    expect(serializedLog).not.toContain('secret-jwt');
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Une erreur interne est survenue.',
+        requestId: 'req-123',
+      }),
+    );
+
+    errorSpy.mockRestore();
+  });
+});

--- a/src/shared/filters/http-exception.filter.ts
+++ b/src/shared/filters/http-exception.filter.ts
@@ -6,7 +6,8 @@ import {
   HttpStatus,
   Logger,
 } from '@nestjs/common';
-import { Request, Response } from 'express';
+import { Response } from 'express';
+import { RequestWithId } from '../middleware/request-observability.middleware';
 
 @Catch()
 export class AllExceptionsFilter implements ExceptionFilter {
@@ -15,7 +16,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
   catch(exception: unknown, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
-    const request = ctx.getRequest<Request>();
+    const request = ctx.getRequest<RequestWithId>();
 
     const status =
       exception instanceof HttpException
@@ -29,12 +30,26 @@ export class AllExceptionsFilter implements ExceptionFilter {
         : 'Une erreur interne est survenue.';
 
     if (status >= 500) {
-      this.logger.error(exception);
+      this.logger.error(
+        JSON.stringify({
+          event: 'http_exception',
+          service: 'elintys-api',
+          requestId: request.requestId,
+          method: request.method,
+          route: request.route?.path ?? request.path,
+          status,
+          errorType:
+            exception instanceof Error
+              ? exception.constructor.name
+              : 'UnknownException',
+        }),
+      );
     }
 
     response.status(status).json({
       statusCode: status,
       message,
+      requestId: request.requestId,
       timestamp: new Date().toISOString(),
       path: request.url,
     });

--- a/src/shared/middleware/request-observability.middleware.spec.ts
+++ b/src/shared/middleware/request-observability.middleware.spec.ts
@@ -1,0 +1,95 @@
+import { EventEmitter } from 'node:events';
+import { NextFunction, Request, Response } from 'express';
+import {
+  createRequestObservabilityMiddleware,
+  RequestWithId,
+  resolveRequestId,
+} from './request-observability.middleware';
+
+describe('request observability middleware', () => {
+  it('conserve un x-request-id entrant valide', () => {
+    expect(resolveRequestId('web:01HR.test-42')).toBe('web:01HR.test-42');
+  });
+
+  it.each([
+    '',
+    'contains spaces',
+    'contains\nnewline',
+    'a'.repeat(129),
+  ])('remplace un x-request-id absent ou invalide', (headerValue) => {
+    expect(resolveRequestId(headerValue || undefined)).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('propage le request id et journalise une ligne JSON sans query string', () => {
+    const logger = { log: jest.fn() };
+    const middleware = createRequestObservabilityMiddleware('test', logger);
+    const request = {
+      baseUrl: '/api/v1',
+      get: jest.fn().mockReturnValue('req_frontend-123'),
+      method: 'GET',
+      path: '/events',
+      route: { path: '/events' },
+    } as unknown as RequestWithId;
+    const emitter = new EventEmitter();
+    const response = Object.assign(emitter, {
+      setHeader: jest.fn(),
+      statusCode: 200,
+    }) as unknown as Response;
+    const next = jest.fn() as NextFunction;
+
+    middleware(request, response, next);
+    emitter.emit('finish');
+
+    expect(request.requestId).toBe('req_frontend-123');
+    expect(response.setHeader).toHaveBeenCalledWith(
+      'x-request-id',
+      'req_frontend-123',
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(logger.log).toHaveBeenCalledTimes(1);
+
+    const logEntry = JSON.parse(logger.log.mock.calls[0][0] as string);
+    expect(logEntry).toEqual(
+      expect.objectContaining({
+        event: 'http_request',
+        service: 'elintys-api',
+        environment: 'test',
+        requestId: 'req_frontend-123',
+        method: 'GET',
+        route: '/api/v1/events',
+        status: 200,
+      }),
+    );
+    expect(logEntry.durationMs).toEqual(expect.any(Number));
+    expect(logger.log.mock.calls[0][0]).not.toContain('?');
+  });
+
+  it('ne journalise jamais les en-têtes, cookies ou paramètres de requête', () => {
+    const logger = { log: jest.fn() };
+    const middleware = createRequestObservabilityMiddleware('test', logger);
+    const request = {
+      baseUrl: '/api/v1',
+      cookies: { access_token: 'secret-jwt' },
+      get: jest.fn().mockReturnValue(undefined),
+      headers: { authorization: 'Bearer secret-jwt' },
+      method: 'POST',
+      path: '/auth/login',
+      query: { email: 'person@example.com' },
+      route: { path: '/auth/login' },
+    } as unknown as Request;
+    const emitter = new EventEmitter();
+    const response = Object.assign(emitter, {
+      setHeader: jest.fn(),
+      statusCode: 401,
+    }) as unknown as Response;
+
+    middleware(request, response, jest.fn());
+    emitter.emit('finish');
+
+    const serializedLog = logger.log.mock.calls[0][0] as string;
+    expect(serializedLog).not.toContain('secret-jwt');
+    expect(serializedLog).not.toContain('person@example.com');
+  });
+});

--- a/src/shared/middleware/request-observability.middleware.ts
+++ b/src/shared/middleware/request-observability.middleware.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from 'node:crypto';
+import { Logger } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+
+export interface RequestWithId extends Request {
+  requestId?: string;
+}
+
+export interface StructuredLogger {
+  log(message: string): void;
+}
+
+export function resolveRequestId(headerValue: string | undefined): string {
+  return headerValue && REQUEST_ID_PATTERN.test(headerValue)
+    ? headerValue
+    : randomUUID();
+}
+
+function resolveRoute(request: Request): string {
+  const matchedPath =
+    typeof request.route?.path === 'string' ? request.route.path : request.path;
+
+  return `${request.baseUrl ?? ''}${matchedPath || '/'}`;
+}
+
+export function createRequestObservabilityMiddleware(
+  environment: string,
+  logger: StructuredLogger = new Logger('HttpObservability'),
+) {
+  return (
+    request: RequestWithId,
+    response: Response,
+    next: NextFunction,
+  ): void => {
+    const startedAt = process.hrtime.bigint();
+    const requestId = resolveRequestId(request.get('x-request-id'));
+
+    request.requestId = requestId;
+    response.setHeader('x-request-id', requestId);
+
+    response.once('finish', () => {
+      const durationMs =
+        Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+
+      logger.log(
+        JSON.stringify({
+          event: 'http_request',
+          service: 'elintys-api',
+          environment,
+          requestId,
+          method: request.method,
+          route: resolveRoute(request),
+          status: response.statusCode,
+          durationMs: Math.round(durationMs * 100) / 100,
+        }),
+      );
+    });
+
+    next();
+  };
+}

--- a/src/shared/middleware/trusted-origin.middleware.spec.ts
+++ b/src/shared/middleware/trusted-origin.middleware.spec.ts
@@ -1,0 +1,75 @@
+import {
+  createTrustedOriginMiddleware,
+  normalizeAllowedOrigins,
+} from './trusted-origin.middleware';
+
+describe('trusted origin middleware', () => {
+  it('normalise et déduplique les origines exactes', () => {
+    expect(
+      normalizeAllowedOrigins([
+        'https://app.dev.elintys.app',
+        'https://app.dev.elintys.app',
+        '',
+      ]),
+    ).toEqual(['https://app.dev.elintys.app']);
+  });
+
+  it.each([
+    'javascript:alert(1)',
+    'https://app.dev.elintys.app/path',
+    'https://app.dev.elintys.app/',
+    'not-a-url',
+  ])('rejette une origine configurée non exacte: %s', (origin) => {
+    expect(() => normalizeAllowedOrigins([origin])).toThrow();
+  });
+
+  function run(method: string, origin?: string) {
+    const next = jest.fn();
+    const json = jest.fn();
+    const status = jest.fn(() => ({ json }));
+    const request = {
+      method,
+      path: '/api/v1/events',
+      requestId: 'request-id',
+      get: jest.fn((header: string) =>
+        header.toLowerCase() === 'origin' ? origin : undefined,
+      ),
+    };
+    const response = { status };
+
+    createTrustedOriginMiddleware(['https://app.dev.elintys.app'])(
+      request as never,
+      response as never,
+      next,
+    );
+
+    return { next, status, json };
+  }
+
+  it('autorise les lectures quelle que soit leur origine', () => {
+    expect(run('GET', 'https://evil.example').next).toHaveBeenCalled();
+  });
+
+  it('autorise une écriture depuis le frontend exact', () => {
+    expect(
+      run('POST', 'https://app.dev.elintys.app').next,
+    ).toHaveBeenCalled();
+  });
+
+  it('autorise les clients non navigateur sans en-tête Origin', () => {
+    expect(run('PATCH').next).toHaveBeenCalled();
+  });
+
+  it('refuse une écriture navigateur venant d’une autre origine', () => {
+    const result = run('DELETE', 'https://evil.example');
+
+    expect(result.next).not.toHaveBeenCalled();
+    expect(result.status).toHaveBeenCalledWith(403);
+    expect(result.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 403,
+        requestId: 'request-id',
+      }),
+    );
+  });
+});

--- a/src/shared/middleware/trusted-origin.middleware.ts
+++ b/src/shared/middleware/trusted-origin.middleware.ts
@@ -1,0 +1,61 @@
+import { NextFunction, Response } from 'express';
+import { RequestWithId } from './request-observability.middleware';
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+export function normalizeAllowedOrigins(origins: string[]): string[] {
+  return [...new Set(origins.filter(Boolean).map((origin) => {
+    let parsed: URL;
+
+    try {
+      parsed = new URL(origin);
+    } catch {
+      throw new Error(`Invalid configured frontend origin: ${origin}`);
+    }
+
+    if (!['http:', 'https:'].includes(parsed.protocol) || parsed.origin !== origin) {
+      throw new Error(
+        `Configured frontend origin must be an absolute HTTP(S) origin without a path: ${origin}`,
+      );
+    }
+
+    return parsed.origin;
+  }))];
+}
+
+/**
+ * Rejects browser writes coming from an untrusted Origin. This complements
+ * CORS: browsers can still submit some cross-origin requests even when their
+ * response is unreadable, so CORS alone is not a CSRF defense.
+ *
+ * Requests without an Origin are retained for server-to-server and native
+ * clients. Web browsers attach Origin to cross-origin unsafe requests.
+ */
+export function createTrustedOriginMiddleware(allowedOrigins: string[]) {
+  const trustedOrigins = new Set(normalizeAllowedOrigins(allowedOrigins));
+
+  return (
+    request: RequestWithId,
+    response: Response,
+    next: NextFunction,
+  ): void => {
+    if (SAFE_METHODS.has(request.method.toUpperCase())) {
+      next();
+      return;
+    }
+
+    const origin = request.get('origin');
+    if (!origin || trustedOrigins.has(origin)) {
+      next();
+      return;
+    }
+
+    response.status(403).json({
+      statusCode: 403,
+      message: 'Origine de requête non autorisée.',
+      requestId: request.requestId,
+      timestamp: new Date().toISOString(),
+      path: request.path,
+    });
+  };
+}

--- a/src/shared/utils/escape-regexp.spec.ts
+++ b/src/shared/utils/escape-regexp.spec.ts
@@ -1,0 +1,9 @@
+import { escapeRegExp } from './escape-regexp';
+
+describe('escapeRegExp', () => {
+  it('neutralise les métacaractères avant une recherche MongoDB', () => {
+    expect(escapeRegExp('Montréal.*(test)')).toBe(
+      'Montréal\\.\\*\\(test\\)',
+    );
+  });
+});

--- a/src/shared/utils/escape-regexp.ts
+++ b/src/shared/utils/escape-regexp.ts
@@ -1,0 +1,3 @@
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
## Résumé

- isole les médias Cloudinary par environnement sous `Elintys/dev/...` et `Elintys/prod/...`
- sécurise les cookies inter-domaines, valide les origines d’écriture et ajoute la corrélation `x-request-id`
- aligne les filtres publics événements, prestataires et lieux avec des requêtes bornées
- ajoute un seed de développement idempotent avec au moins 10 prestataires, 10 lieux et 10 événements publics
- documente le stockage média, le seed, les cookies et l’observabilité

## Validation

- 37 suites Jest, 319 tests réussis
- build NestJS réussi
- lint sans erreur (2 avertissements historiques)
- audit runtime : 0 vulnérabilité
- `git diff --check` réussi

## Déploiement

Le service Render `elintys-api-dev` suit automatiquement la branche `dev`. Après fusion, un job Render unique exécutera `npm run seed:dev`.
