### PR TITLE
fix: isolate hosted authentication cookies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,5 +35,5 @@ ANTHROPIC_API_KEY=
 # Frontend
 FRONTEND_URL=http://localhost:3000
 CORS_ORIGINS=
-# Omettre en local. Développement hébergé: .dev.elintys.app; production: .elintys.com
+# Toujours omettre: les cookies d'authentification sont host-only.
 COOKIE_DOMAIN=

--- a/docs/auth-cookies-and-observability.md
+++ b/docs/auth-cookies-and-observability.md
@@ -2,24 +2,20 @@
 
 ## Domaines apparentés
 
-L'API conserve les jetons dans des cookies `HttpOnly`, `SameSite=Lax` et
-`Secure` dès qu'elle est déployée (`NODE_ENV=production`) ou qu'un domaine de
-cookie est configuré.
+L'API conserve les jetons dans des cookies host-only `HttpOnly`,
+`SameSite=Lax` et `Secure` dès qu'elle est déployée
+(`NODE_ENV=production`). Aucun attribut `Domain` n'est émis.
 
 | Environnement | Frontend | API | `COOKIE_DOMAIN` |
 | --- | --- | --- | --- |
-| Développement hébergé | `https://app.dev.elintys.app` | `https://api.dev.elintys.app` | `.dev.elintys.app` |
-| Production | `https://app.elintys.com` | `https://api.elintys.com` | `.elintys.com` |
+| Développement hébergé | `https://dev.elintys.com` | `https://api.dev.elintys.com` | omis |
+| Production | `https://app.elintys.com` | `https://api.elintys.com` | omis |
 
-`COOKIE_DOMAIN` doit commencer par un point, être un nom DNS valide et être un
-domaine parent de l'hôte défini par `FRONTEND_URL`. L'API refuse de démarrer si
-une valeur configurée ne respecte pas ces contraintes. `ELINTYS_ENV=dev`
-impose `.dev.elintys.app`, tandis que `ELINTYS_ENV=prod` impose `.elintys.com`.
-Les domaines enregistrables distincts empêchent un hôte de développement de
-recevoir ou d'émettre les cookies de production.
-Dans un runtime déployé (`NODE_ENV=production`), `ELINTYS_ENV` et
-`COOKIE_DOMAIN` sont obligatoires. En local, la variable de domaine doit être
-omise pour utiliser un cookie limité à l'hôte.
+`COOKIE_DOMAIN` doit rester vide dans tous les environnements. L'API refuse de
+démarrer si une valeur est définie. Le navigateur limite ainsi les cookies à
+l'hôte API qui les a émis: `api.dev.elintys.com` en développement et
+`api.elintys.com` en production. `ELINTYS_ENV` reste obligatoire dans un
+runtime déployé afin d'isoler la base de données et les médias.
 
 La suppression des cookies réutilise exactement le même domaine, chemin et les
 mêmes attributs de sécurité que leur création.
@@ -29,10 +25,11 @@ mêmes attributs de sécurité que leur création.
 CORS est limité aux origines exactes définies par `FRONTEND_URL` et
 `CORS_ORIGINS`. En complément, les requêtes navigateur `POST`, `PUT`, `PATCH`
 et `DELETE` dont l'en-tête `Origin` ne correspond pas à cette liste sont
-refusées avec un statut 403. Ce contrôle évite qu'un site tiers déclenche une
-écriture authentifiée sans pouvoir lire la réponse. Les lectures, les
-pré-requêtes `OPTIONS` et les clients serveur ou natifs sans en-tête `Origin`
-restent autorisés.
+refusées avec un statut 403. Une écriture sans `Origin` est également refusée
+si elle transporte un cookie d'authentification. Ce contrôle évite qu'un site
+tiers déclenche une écriture authentifiée sans pouvoir lire la réponse. Les
+lectures, les pré-requêtes `OPTIONS` et les clients serveur ou natifs sans
+cookie restent autorisés.
 
 ## Corrélation et logs réseau
 

--- a/docs/render-development.md
+++ b/docs/render-development.md
@@ -11,9 +11,12 @@ Le fichier `render.yaml` décrit le service `elintys-api-dev` :
 
 Les secrets sont déclarés avec `sync: false` et doivent être fournis dans
 Render. Ils ne sont jamais stockés dans Git. `NODE_ENV=production` reste requis
-sur l'API de développement afin d'activer les cookies HTTPS inter-domaines;
-l'environnement fonctionnel reste identifié par la branche Render `dev`.
+sur l'API de développement afin d'activer les cookies `Secure` et les autres
+protections de production; `ELINTYS_ENV=dev` isole les données et les médias.
 
-`FRONTEND_URL` désigne l'URL Vercel stable de la branche `dev`.
+Le frontend de développement est `https://dev.elintys.com` et l'API est
+exposée par `https://api.dev.elintys.com`. `FRONTEND_URL` vaut donc exactement
+`https://dev.elintys.com`. `COOKIE_DOMAIN` doit rester omis afin que les
+cookies d'authentification restent limités à l'hôte API.
 `CORS_ORIGINS` accepte une liste séparée par des virgules pour les autres
 origines Preview explicitement autorisées.

--- a/render.yaml
+++ b/render.yaml
@@ -44,8 +44,6 @@ services:
       - key: STRIPE_WEBHOOK_SECRET
         sync: false
       - key: FRONTEND_URL
-        sync: false
-      - key: COOKIE_DOMAIN
-        value: .dev.elintys.app
+        value: https://dev.elintys.com
       - key: CORS_ORIGINS
         sync: false

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -8,12 +8,7 @@ export default () => {
     nodeEnv,
   );
   const frontendUrl = process.env.FRONTEND_URL ?? 'http://localhost:3000';
-  const cookieDomain = resolveCookieDomain(
-    process.env.COOKIE_DOMAIN,
-    frontendUrl,
-    elintysEnv,
-    nodeEnv === 'production',
-  );
+  resolveCookieDomain(process.env.COOKIE_DOMAIN);
 
   return {
     port: parseInt(process.env.PORT ?? '3001', 10),
@@ -45,8 +40,7 @@ export default () => {
     },
     frontendUrl,
     authCookie: {
-      domain: cookieDomain,
-      secure: nodeEnv === 'production' || cookieDomain !== undefined,
+      secure: nodeEnv === 'production',
     },
   };
 };

--- a/src/config/cookie-domain.spec.ts
+++ b/src/config/cookie-domain.spec.ts
@@ -1,81 +1,21 @@
 import { resolveCookieDomain } from './cookie-domain';
 
 describe('resolveCookieDomain', () => {
-  it('normalise un domaine parent valide', () => {
-    expect(
-      resolveCookieDomain(
-        '  .DEV.ELINTYS.APP ',
-        'https://app.dev.elintys.app',
-        'dev',
-      ),
-    ).toBe('.dev.elintys.app');
-  });
-
-  it('accepte le domaine parent de production', () => {
-    expect(
-      resolveCookieDomain('.elintys.com', 'https://app.elintys.com', 'prod'),
-    ).toBe('.elintys.com');
-  });
-
-  it('laisse les cookies host-only en développement local', () => {
-    expect(
-      resolveCookieDomain(undefined, 'http://localhost:3100', 'dev'),
-    ).toBeUndefined();
-  });
+  it.each([undefined, '', '   '])(
+    'conserve les cookies host-only lorsque COOKIE_DOMAIN=%p',
+    (domain) => {
+      expect(resolveCookieDomain(domain)).toBeUndefined();
+    },
+  );
 
   it.each([
-    'dev.elintys.app',
-    'https://dev.elintys.app',
-    '.dev.elintys.app/path',
-    '.dev.elintys.app:443',
-    '.*.elintys.com',
-    '.localhost',
-    '.127.0.0.1',
-  ])('rejette le format de domaine non sécurisé %s', (domain) => {
-    expect(() =>
-      resolveCookieDomain(domain, 'https://app.dev.elintys.app', 'dev'),
-    ).toThrow('COOKIE_DOMAIN');
-  });
-
-  it("rejette un domaine qui n'est pas parent du frontend", () => {
-    expect(() =>
-      resolveCookieDomain('.elintys.com', 'https://example.com', 'prod'),
-    ).toThrow('parent domain');
-  });
-
-  it('rejette les faux suffixes apparentés', () => {
-    expect(() =>
-      resolveCookieDomain(
-        '.elintys.com',
-        'https://app.elintys.com.evil.test',
-        'prod',
-      ),
-    ).toThrow('parent domain');
-  });
-
-  it('empêche le développement de partager les cookies avec la production', () => {
-    expect(() =>
-      resolveCookieDomain(
-        '.elintys.app',
-        'https://app.dev.elintys.app',
-        'dev',
-      ),
-    ).toThrow('ELINTYS_ENV=dev');
-  });
-
-  it('empêche la production d’utiliser le domaine de développement', () => {
-    expect(() =>
-      resolveCookieDomain(
-        '.dev.elintys.app',
-        'https://app.dev.elintys.app',
-        'prod',
-      ),
-    ).toThrow('ELINTYS_ENV=prod');
-  });
-
-  it('exige un domaine de cookie dans un environnement déployé', () => {
-    expect(() =>
-      resolveCookieDomain(undefined, 'https://app.dev.elintys.app', 'dev', true),
-    ).toThrow('required');
+    '.dev.elintys.com',
+    '.elintys.com',
+    'dev.elintys.com',
+    'https://dev.elintys.com',
+  ])('refuse tout attribut Domain: %s', (domain) => {
+    expect(() => resolveCookieDomain(domain)).toThrow(
+      'authentication cookies are host-only',
+    );
   });
 });

--- a/src/config/cookie-domain.ts
+++ b/src/config/cookie-domain.ts
@@ -1,74 +1,16 @@
-import { ElintysEnvironment } from './elintys-environment';
-
-const COOKIE_DOMAIN_PATTERN =
-  /^\.(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
-
-function getFrontendHostname(frontendUrl: string): string {
-  let parsedUrl: URL;
-
-  try {
-    parsedUrl = new URL(frontendUrl);
-  } catch {
-    throw new Error('FRONTEND_URL must be an absolute HTTP(S) URL.');
-  }
-
-  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
-    throw new Error('FRONTEND_URL must use HTTP or HTTPS.');
-  }
-
-  return parsedUrl.hostname.toLowerCase();
-}
-
 /**
- * Validates and normalizes the optional parent domain used by authentication
- * cookies. A leading dot is required intentionally so a host-only typo cannot
- * silently break sessions between the app and API sibling subdomains.
+ * Elintys deliberately uses host-only authentication cookies. Defining a
+ * Domain attribute would allow the cookie to cross an environment boundary
+ * through sibling or descendant subdomains.
  */
 export function resolveCookieDomain(
   rawDomain: string | undefined,
-  frontendUrl: string,
-  environment: ElintysEnvironment,
-  requireDomain = false,
-): string | undefined {
-  const trimmedDomain = rawDomain?.trim();
-
-  if (!trimmedDomain) {
-    if (requireDomain) {
-      throw new Error(
-        'COOKIE_DOMAIN is required for a deployed environment.',
-      );
-    }
-
-    return undefined;
-  }
-
-  const domain = trimmedDomain.toLowerCase();
-
-  if (!COOKIE_DOMAIN_PATTERN.test(domain)) {
+): undefined {
+  if (rawDomain?.trim()) {
     throw new Error(
-      'COOKIE_DOMAIN must be a parent DNS domain with a leading dot (for example .dev.elintys.app).',
+      'COOKIE_DOMAIN must be omitted: authentication cookies are host-only.',
     );
   }
 
-  const frontendHostname = getFrontendHostname(frontendUrl);
-  const bareDomain = domain.slice(1);
-  const isRelatedDomain =
-    frontendHostname === bareDomain || frontendHostname.endsWith(domain);
-
-  if (!isRelatedDomain) {
-    throw new Error(
-      'COOKIE_DOMAIN must be a parent domain of the FRONTEND_URL hostname.',
-    );
-  }
-
-  const expectedDomain =
-    environment === 'dev' ? '.dev.elintys.app' : '.elintys.com';
-
-  if (domain !== expectedDomain) {
-    throw new Error(
-      `COOKIE_DOMAIN must be ${expectedDomain} when ELINTYS_ENV=${environment}.`,
-    );
-  }
-
-  return domain;
+  return undefined;
 }

--- a/src/modules/auth/auth.controller.spec.ts
+++ b/src/modules/auth/auth.controller.spec.ts
@@ -25,10 +25,6 @@ const mockConfigService = {
     if (key === 'authCookie.secure') return true;
     return 'value';
   }),
-  get: jest.fn().mockImplementation((key: string) => {
-    if (key === 'authCookie.domain') return '.dev.elintys.com';
-    return undefined;
-  }),
 };
 
 const mockResponse = (): Partial<Response> => ({
@@ -75,13 +71,16 @@ describe('AuthController', () => {
         'access_token',
         'access_token',
         expect.objectContaining({
-          domain: '.dev.elintys.com',
           httpOnly: true,
           path: '/',
           sameSite: 'lax',
           secure: true,
         }),
       );
+      const accessCookieOptions = (res.cookie as jest.Mock).mock.calls.find(
+        ([name]) => name === 'access_token',
+      )?.[2] as Record<string, unknown>;
+      expect(accessCookieOptions).not.toHaveProperty('domain');
       expect(result).toHaveProperty('user');
       expect(result).not.toHaveProperty('accessToken');
       expect(result).not.toHaveProperty('refreshToken');
@@ -170,7 +169,6 @@ describe('AuthController', () => {
 
       expect(mockAuthService.logoutFromCookie).toHaveBeenCalledWith('old_cookie_token');
       const expectedOptions = {
-        domain: '.dev.elintys.com',
         httpOnly: true,
         path: '/',
         sameSite: 'lax',
@@ -178,6 +176,7 @@ describe('AuthController', () => {
       };
       expect(res.clearCookie).toHaveBeenCalledWith('access_token', expectedOptions);
       expect(res.clearCookie).toHaveBeenCalledWith('refresh_token', expectedOptions);
+      expect(expectedOptions).not.toHaveProperty('domain');
       expect(result).toEqual({ message: 'Déconnecté avec succès' });
     });
 
@@ -191,11 +190,11 @@ describe('AuthController', () => {
       expect(mockAuthService.logoutFromCookie).toHaveBeenCalledWith(undefined);
       expect(res.clearCookie).toHaveBeenCalledWith(
         'access_token',
-        expect.objectContaining({ domain: '.dev.elintys.com', path: '/' }),
+        expect.objectContaining({ path: '/' }),
       );
       expect(res.clearCookie).toHaveBeenCalledWith(
         'refresh_token',
-        expect.objectContaining({ domain: '.dev.elintys.com', path: '/' }),
+        expect.objectContaining({ path: '/' }),
       );
     });
   });

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -34,13 +34,10 @@ export class AuthController {
   ) {}
 
   private get sharedCookieOptions(): CookieOptions {
-    const domain = this.configService.get<string>('authCookie.domain');
-
     return {
       httpOnly: true,
       secure: this.configService.getOrThrow<boolean>('authCookie.secure'),
       sameSite: 'lax',
-      ...(domain ? { domain } : {}),
       path: '/',
     };
   }

--- a/src/shared/middleware/trusted-origin.middleware.spec.ts
+++ b/src/shared/middleware/trusted-origin.middleware.spec.ts
@@ -7,23 +7,23 @@ describe('trusted origin middleware', () => {
   it('normalise et déduplique les origines exactes', () => {
     expect(
       normalizeAllowedOrigins([
-        'https://app.dev.elintys.app',
-        'https://app.dev.elintys.app',
+        'https://dev.elintys.com',
+        'https://dev.elintys.com',
         '',
       ]),
-    ).toEqual(['https://app.dev.elintys.app']);
+    ).toEqual(['https://dev.elintys.com']);
   });
 
   it.each([
     'javascript:alert(1)',
-    'https://app.dev.elintys.app/path',
-    'https://app.dev.elintys.app/',
+    'https://dev.elintys.com/path',
+    'https://dev.elintys.com/',
     'not-a-url',
   ])('rejette une origine configurée non exacte: %s', (origin) => {
     expect(() => normalizeAllowedOrigins([origin])).toThrow();
   });
 
-  function run(method: string, origin?: string) {
+  function run(method: string, origin?: string, authenticated = false) {
     const next = jest.fn();
     const json = jest.fn();
     const status = jest.fn(() => ({ json }));
@@ -31,13 +31,14 @@ describe('trusted origin middleware', () => {
       method,
       path: '/api/v1/events',
       requestId: 'request-id',
+      cookies: authenticated ? { access_token: 'private-token' } : {},
       get: jest.fn((header: string) =>
         header.toLowerCase() === 'origin' ? origin : undefined,
       ),
     };
     const response = { status };
 
-    createTrustedOriginMiddleware(['https://app.dev.elintys.app'])(
+    createTrustedOriginMiddleware(['https://dev.elintys.com'])(
       request as never,
       response as never,
       next,
@@ -52,12 +53,19 @@ describe('trusted origin middleware', () => {
 
   it('autorise une écriture depuis le frontend exact', () => {
     expect(
-      run('POST', 'https://app.dev.elintys.app').next,
+      run('POST', 'https://dev.elintys.com').next,
     ).toHaveBeenCalled();
   });
 
   it('autorise les clients non navigateur sans en-tête Origin', () => {
     expect(run('PATCH').next).toHaveBeenCalled();
+  });
+
+  it('refuse une écriture authentifiée par cookie sans en-tête Origin', () => {
+    const result = run('PATCH', undefined, true);
+
+    expect(result.next).not.toHaveBeenCalled();
+    expect(result.status).toHaveBeenCalledWith(403);
   });
 
   it('refuse une écriture navigateur venant d’une autre origine', () => {

--- a/src/shared/middleware/trusted-origin.middleware.ts
+++ b/src/shared/middleware/trusted-origin.middleware.ts
@@ -28,8 +28,9 @@ export function normalizeAllowedOrigins(origins: string[]): string[] {
  * CORS: browsers can still submit some cross-origin requests even when their
  * response is unreadable, so CORS alone is not a CSRF defense.
  *
- * Requests without an Origin are retained for server-to-server and native
- * clients. Web browsers attach Origin to cross-origin unsafe requests.
+ * Requests without an Origin remain available to server/native clients only
+ * when they do not carry authentication cookies. A cookie-authenticated write
+ * without Origin fails closed.
  */
 export function createTrustedOriginMiddleware(allowedOrigins: string[]) {
   const trustedOrigins = new Set(normalizeAllowedOrigins(allowedOrigins));
@@ -45,7 +46,16 @@ export function createTrustedOriginMiddleware(allowedOrigins: string[]) {
     }
 
     const origin = request.get('origin');
-    if (!origin || trustedOrigins.has(origin)) {
+    if (origin && trustedOrigins.has(origin)) {
+      next();
+      return;
+    }
+
+    const hasAuthCookie = Boolean(
+      request.cookies?.access_token || request.cookies?.refresh_token,
+    );
+
+    if (!origin && !hasAuthCookie) {
       next();
       return;
     }


### PR DESCRIPTION
## Résumé
- utilise des cookies Secure HttpOnly SameSite=Lax limités à l’hôte API
- refuse toute configuration COOKIE_DOMAIN afin d’isoler strictement dev et production
- renforce le contrôle Origin des écritures authentifiées par cookie
- aligne la documentation sur dev.elintys.com et api.dev.elintys.com

## Validation
- 37 suites Jest réussies, 312 tests
- build Nest réussi
- lint ciblé réussi
- git diff --check réussi