### PR TITLE
Sprint 3 — Wave E — System-wide E2E & Release Hardening

### DIFF
--- a/src/modules/guests/dto/query-guests.dto.ts
+++ b/src/modules/guests/dto/query-guests.dto.ts
@@ -1,0 +1,17 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class QueryGuestsDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 50;
+}

--- a/src/modules/guests/guests.controller.spec.ts
+++ b/src/modules/guests/guests.controller.spec.ts
@@ -49,15 +49,15 @@ describe('GuestsController', () => {
     it('délègue à guestsService.findAll avec les paramètres par défaut', async () => {
       mockGuestsService.findAll.mockResolvedValue({ data: [], total: 0 });
 
-      await controller.findAll('event-id', mockUser as never, undefined, undefined);
+      await controller.findAll('event-id', mockUser as never, {});
 
       expect(mockGuestsService.findAll).toHaveBeenCalledWith('event-id', mockUser.sub, 1, 50, mockUser.roles);
     });
 
-    it('passe les valeurs de page et limit parsées', async () => {
+    it('passe les valeurs de page et limit validées', async () => {
       mockGuestsService.findAll.mockResolvedValue({ data: [], total: 0 });
 
-      await controller.findAll('event-id', mockUser as never, '2', '25');
+      await controller.findAll('event-id', mockUser as never, { page: 2, limit: 25 });
 
       expect(mockGuestsService.findAll).toHaveBeenCalledWith('event-id', mockUser.sub, 2, 25, mockUser.roles);
     });

--- a/src/modules/guests/guests.controller.ts
+++ b/src/modules/guests/guests.controller.ts
@@ -7,6 +7,7 @@ import { BulkCreateGuestDto } from './dto/bulk-create-guest.dto';
 import { CurrentUser, JwtPayload } from '../../shared/decorators/current-user.decorator';
 import { ParseObjectIdPipe } from '../../shared/pipes/parse-object-id.pipe';
 import { Roles, Role } from '../../shared/decorators/roles.decorator';
+import { QueryGuestsDto } from './dto/query-guests.dto';
 
 @ApiTags('Guests')
 @ApiBearerAuth('access-token')
@@ -53,14 +54,13 @@ export class GuestsController {
   findAll(
     @Param('eventId', ParseObjectIdPipe) eventId: string,
     @CurrentUser() user: JwtPayload,
-    @Query('page') page?: string,
-    @Query('limit') limit?: string,
+    @Query() query: QueryGuestsDto,
   ) {
     return this.guestsService.findAll(
       eventId,
       user.sub,
-      page ? parseInt(page, 10) : 1,
-      limit ? parseInt(limit, 10) : 50,
+      query.page ?? 1,
+      query.limit ?? 50,
       user.roles,
     );
   }

--- a/src/modules/notifications/dto/query-notifications.dto.ts
+++ b/src/modules/notifications/dto/query-notifications.dto.ts
@@ -1,0 +1,19 @@
+import { Transform, Type } from 'class-transformer';
+import { IsBoolean, IsInt, IsOptional, Min } from 'class-validator';
+
+export class QueryNotificationsDto {
+  @IsOptional()
+  @Transform(({ value }: { value: unknown }) => {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return value;
+  })
+  @IsBoolean()
+  unreadOnly?: boolean = false;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+}

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -11,6 +11,7 @@ import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { NotificationsService } from './notifications.service';
 import { CurrentUser, JwtPayload } from '../../shared/decorators/current-user.decorator';
 import { ParseObjectIdPipe } from '../../shared/pipes/parse-object-id.pipe';
+import { QueryNotificationsDto } from './dto/query-notifications.dto';
 
 @ApiTags('Notifications')
 @Controller('notifications')
@@ -34,12 +35,11 @@ export class NotificationsController {
   @ApiQuery({ name: 'page', required: false, type: Number })
   findMine(
     @CurrentUser() user: JwtPayload,
-    @Query('unreadOnly') unreadOnly?: string,
-    @Query('page') page?: string,
+    @Query() query: QueryNotificationsDto,
   ) {
     return this.notificationsService.findByUser(user.sub, {
-      unreadOnly: unreadOnly === 'true',
-      page: page ? parseInt(page, 10) : 1,
+      unreadOnly: query.unreadOnly ?? false,
+      page: query.page ?? 1,
     });
   }
 

--- a/test/guests-pagination.e2e-spec.ts
+++ b/test/guests-pagination.e2e-spec.ts
@@ -1,0 +1,54 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { GuestsController } from '../src/modules/guests/guests.controller';
+import { GuestsService } from '../src/modules/guests/guests.service';
+
+describe('Guests HTTP pagination contract (e2e)', () => {
+  let app: INestApplication;
+
+  const guestsService = {
+    findAll: jest.fn().mockResolvedValue({ data: [], total: 0, page: 1, limit: 50 }),
+  };
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [GuestsController],
+      providers: [{ provide: GuestsService, useValue: guestsService }],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use((req: { user?: unknown }, _res: unknown, next: () => void) => {
+      req.user = {
+        sub: '507f1f77bcf86cd799439011',
+        email: 'qa@example.com',
+        roles: ['organizer'],
+      };
+      next();
+    });
+    app.useGlobalPipes(new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }));
+    await app.init();
+  });
+
+  afterAll(async () => app.close());
+  beforeEach(() => jest.clearAllMocks());
+
+  it.each([
+    { page: '0' },
+    { page: 'abc' },
+    { limit: '0' },
+    { limit: '101' },
+    { limit: '1.5' },
+  ])('rejette la pagination invalide : %p', async (query) => {
+    await request(app.getHttpServer())
+      .get('/events/507f1f77bcf86cd799439012/guests')
+      .query(query)
+      .expect(400);
+
+    expect(guestsService.findAll).not.toHaveBeenCalled();
+  });
+});

--- a/test/notifications.e2e-spec.ts
+++ b/test/notifications.e2e-spec.ts
@@ -1,0 +1,70 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { NotificationsController } from '../src/modules/notifications/notifications.controller';
+import { NotificationsService } from '../src/modules/notifications/notifications.service';
+
+describe('Notifications HTTP routing contract (e2e)', () => {
+  let app: INestApplication;
+
+  const notificationsService = {
+    markAllRead: jest.fn().mockResolvedValue(undefined),
+    markRead: jest.fn().mockResolvedValue(undefined),
+    findByUser: jest.fn().mockResolvedValue([]),
+    countUnread: jest.fn().mockResolvedValue({ count: 0 }),
+  };
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [NotificationsController],
+      providers: [{ provide: NotificationsService, useValue: notificationsService }],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use((req: { user?: unknown }, _res: unknown, next: () => void) => {
+      req.user = {
+        sub: '507f1f77bcf86cd799439011',
+        email: 'qa@example.com',
+        roles: ['organizer'],
+      };
+      next();
+    });
+    app.useGlobalPipes(new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }));
+    await app.init();
+  });
+
+  afterAll(async () => app.close());
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('résout PATCH /notifications/read-all avant la route paramétrée :id/read', async () => {
+    await request(app.getHttpServer()).patch('/notifications/read-all').expect(204);
+
+    expect(notificationsService.markAllRead).toHaveBeenCalledWith(
+      '507f1f77bcf86cd799439011',
+    );
+    expect(notificationsService.markRead).not.toHaveBeenCalled();
+  });
+
+  it.each(['0', '-1', 'abc', '1.5'])('rejette une pagination invalide : page=%s', async (page) => {
+    await request(app.getHttpServer())
+      .get('/notifications/me')
+      .query({ page })
+      .expect(400);
+
+    expect(notificationsService.findByUser).not.toHaveBeenCalled();
+  });
+
+  it.each(['yes', '1'])('rejette un filtre booléen ambigu : unreadOnly=%s', async (unreadOnly) => {
+    await request(app.getHttpServer())
+      .get('/notifications/me')
+      .query({ unreadOnly })
+      .expect(400);
+
+    expect(notificationsService.findByUser).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Résumé
- valide strictement la pagination Guests et Notifications
- verrouille la résolution de la route Notifications read-all
- ajoute 11 cas HTTP négatifs

## Gates
- lint, typecheck, build : verts
- unitaires : 77 suites, 1 198 tests
- API E2E : 9 suites, 122 tests
- concurrence : 17/17
- npm audit : 0 vulnérabilité

Aucune migration et aucun flux PayPal externe exécuté. PR à ne pas merger automatiquement.